### PR TITLE
Document vector store and agent modules

### DIFF
--- a/purpose_files/cli_combined.purpose.md
+++ b/purpose_files/cli_combined.purpose.md
@@ -35,3 +35,6 @@
 - This CLI structure consolidates multiple pipeline modules into a single entrypoint (`main.py`).
 - Ideal for rapid experimentation, internal QA, or data teams to process corpora at scale.
 - Long-term direction may involve breaking commands into namespace groupings or supporting `--dry-run` and audit modes.
+- New sub-commands `search` and `agent` will expose FAISS retrieval and multi-agent RAG workflows.
+- `search` accepts a natural language query and returns document IDs ranked by semantic similarity.
+- `agent` orchestrates cooperative roles such as Synthesizer and Insight Aggregator while respecting a budget cap.

--- a/purpose_files/core.agent_hub.purpose.md
+++ b/purpose_files/core.agent_hub.purpose.md
@@ -1,0 +1,35 @@
+- @ai-path: core.agent_hub
+- @ai-source-file: agent_hub.py
+- @ai-role: logic
+- @ai-intent: "Spawn and manage cooperative agent sessions sharing a common retriever."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+- @schema-version: 0.2
+- @ai-risk-pii: medium
+- @ai-risk-performance: "Concurrent agent calls can be costly if not budgeted."
+
+# Module: core.agent_hub
+> Minimal orchestration layer for multi-agent RAG workflows.
+
+### 🎯 Intent & Responsibility
+- Instantiate agent sessions based on role definitions and tool sets.
+- Provide shared access to a `Retriever` for context gathering.
+- Step each agent in a loop until tasks are complete.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | role | str | Agent role name (e.g., Synthesizer) |
+| 📥 In | retriever | Retriever | Retrieval interface for context |
+| 📤 Out | response | str | Agent-generated text or tool calls |
+
+### 🔗 Dependencies
+- `core.retrieval.retriever.Retriever`
+- `openai` (for now) via `core.llm`
+- `anyio` (future for async orchestration)
+
+### 🗣 Dialogic Notes
+- Initial roles include **Synthesizer**, **Associative Thinker**, **Insight Aggregator**, and **Amplifier**.
+- Budget tracking hooks will abort loops if monthly cost exceeds configured cap.

--- a/purpose_files/core.retrieval.retriever.purpose.md
+++ b/purpose_files/core.retrieval.retriever.purpose.md
@@ -1,0 +1,35 @@
+- @ai-path: core.retrieval.retriever
+- @ai-source-file: retriever.py
+- @ai-role: logic
+- @ai-intent: "Embed text queries and return top-k document IDs from the vector store."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+- @schema-version: 0.2
+- @ai-risk-pii: low
+- @ai-risk-performance: "Embedding model calls incur latency and cost."
+
+# Module: core.retrieval.retriever
+> Unified interface for semantic search against the FAISS vector store.
+
+### 🎯 Intent & Responsibility
+- Convert query text to embeddings using the configured model.
+- Delegate search to `FaissStore` and return ranked document IDs.
+- Provide an easy-to-mock layer for CLI and future agent use.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | text | str | Search query text |
+| 📥 In | k | int | Number of results to return |
+| 📤 Out | results | List[Tuple[int, float]] | Matching document IDs with scores |
+
+### 🔗 Dependencies
+- `core.embeddings.embedder.embed_text`
+- `core.vectorstore.faiss_store.FaissStore`
+- `numpy`
+
+### 🗣 Dialogic Notes
+- Embedding model is configurable; defaults to OpenAI `text-embedding-3-small`.
+- Agents will call this layer instead of accessing FAISS directly.

--- a/purpose_files/core.utils.budget_tracker.purpose.md
+++ b/purpose_files/core.utils.budget_tracker.purpose.md
@@ -1,0 +1,33 @@
+- @ai-path: core.utils.budget_tracker
+- @ai-source-file: budget_tracker.py
+- @ai-role: utility
+- @ai-intent: "Track and limit API spending across embedding and agent operations."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+- @schema-version: 0.2
+- @ai-risk-pii: none
+- @ai-risk-performance: "Adding checks introduces slight overhead per call."
+
+# Module: core.utils.budget_tracker
+> Simple cost accounting helper that aborts operations when monthly spend exceeds a configured limit.
+
+### 🎯 Intent & Responsibility
+- Wrap OpenAI API calls to accumulate token usage and convert to dollar cost.
+- Provide `check(cost)` and `reset(month)` helpers for CLI and agents.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | max_usd | float | Monthly budget ceiling |
+| 📥 In | cost | float | Cost increment to add |
+| 📤 Out | ok | bool | Whether the call is allowed |
+
+### 🔗 Dependencies
+- `time` for month tracking
+- `pathlib.Path` for optional log persistence
+
+### 🗣 Dialogic Notes
+- Aligns with AGENTS rule `G-08` to respect spending limits.
+- CLI commands and agents import this utility to fail fast when the budget is hit.

--- a/purpose_files/core.vectorstore.faiss_store.purpose.md
+++ b/purpose_files/core.vectorstore.faiss_store.purpose.md
@@ -1,0 +1,37 @@
+- @ai-path: core.vectorstore.faiss_store
+- @ai-source-file: faiss_store.py
+- @ai-role: storage
+- @ai-intent: "Persist and search embedding vectors using a FAISS index with ID mapping."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+- @schema-version: 0.2
+- @ai-risk-pii: low
+- @ai-risk-performance: "Large indexes consume memory; retrieval speed depends on vector count."
+
+# Module: core.vectorstore.faiss_store
+> Lightweight wrapper around FAISS providing add/search and on-disk persistence.
+
+### 🎯 Intent & Responsibility
+- Manage an inner-product FAISS index keyed by document IDs.
+- Provide `add(ids, vecs)`, `search(vec, k)`, and `persist()` methods.
+- Load existing indexes from disk on initialization.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name  | Type | Brief Description |
+|-----------|-------|------|-------------------|
+| 📥 In | ids | List[int] | Unique identifiers for each vector |
+| 📥 In | vecs | np.ndarray | 2D array of float32 vectors |
+| 📥 In | vec | np.ndarray | Query vector for search |
+| 📤 Out | results | List[Tuple[int, float]] | `(id, score)` pairs from search |
+| 📤 Out | index_file | Path | Saved FAISS index on disk |
+
+### 🔗 Dependencies
+- `faiss` – vector index implementation
+- `numpy` – numeric arrays
+- `pathlib.Path` – file handling
+
+### 🗣 Dialogic Notes
+- Designed as a swap-in component for alternative stores like Qdrant or Milvus.
+- Future enhancement: write-ahead log for crash-safe incremental indexing.

--- a/purpose_files/core_config_combined.purpose.md
+++ b/purpose_files/core_config_combined.purpose.md
@@ -28,3 +28,4 @@
 - `get_path_config()` and `get_remote_config()` provide cached access, reloadable via `force_reload=True`.
 - Both `PathConfig` and `RemoteConfig` enforce structure but can be extended to support `.env`, CLI args, or dynamic reloading.
 - This system separates runtime configuration concerns from hardcoded constants, enabling safe parallel use across local and cloud environments.
+- New path entry `vector` will store FAISS index files alongside other outputs.

--- a/purpose_files/core_embeddings_combined.purpose.md
+++ b/purpose_files/core_embeddings_combined.purpose.md
@@ -31,3 +31,5 @@
 - The embedding generation adapts based on the method—"summary" and "meta" pull from JSON metadata, while "parsed"/"raw" use file text directly.
 - JSON output is a lightweight, interoperable format suitable for direct clustering use.
 - A future enhancement could batch texts for API efficiency or allow token truncation thresholds to be configured.
+- Generated vectors are now streamed directly into a FAISS index (`core.vectorstore.faiss_store`).
+- Embedding JSON output is retained for clustering but no longer required for search.

--- a/purpose_files/scripts.pipeline.purpose.md
+++ b/purpose_files/scripts.pipeline.purpose.md
@@ -31,3 +31,4 @@
 - Handles exceptions gracefully at each step; doesn’t halt pipeline on single failure.
 - Embedding method can be aligned with downstream semantic search or classification heuristics.
 - Could be expanded to support logging, dry-run mode, or parallel processing.
+- When embeddings are generated, vectors are simultaneously added to the FAISS index for immediate searchability.


### PR DESCRIPTION
## Summary
- add .purpose docs for upcoming FAISS vector store, retriever, agent hub, and budget tracker
- document new search and agent CLI commands
- describe direct FAISS indexing in embedding and pipeline docs
- note vector index path in config documentation

## Testing
- `PYTHONPATH=src pytest -q` *(fails: FileNotFoundError: path_config.json)*

------
https://chatgpt.com/codex/tasks/task_e_68654ca1d1548323808a52bb33e612cd