### PR TITLE
Deterministic id mapping for FAISS

### DIFF
--- a/intents/2024-06-13__vector_id_map.intent.md
+++ b/intents/2024-06-13__vector_id_map.intent.md
@@ -1,0 +1,3 @@
+Switch hashing to deterministic blake2b for FAISS doc IDs.
+Persist {int_id: doc_id} map for retrieval translation.
+Retriever now returns filenames, not numeric IDs.

--- a/purpose_files/core.retrieval.retriever.purpose.md
+++ b/purpose_files/core.retrieval.retriever.purpose.md
@@ -1,7 +1,7 @@
 - @ai-path: core.retrieval.retriever
 - @ai-source-file: retriever.py
 - @ai-role: logic
-- @ai-intent: "Embed text queries and return top-k document IDs from the vector store."
+- @ai-intent: "Embed text queries and return top-k document filenames from the vector store."
 - @ai-version: 0.1.0
 - @ai-generated: true
 - @ai-verified: false
@@ -15,7 +15,7 @@
 
 ### 🎯 Intent & Responsibility
 - Convert query text to embeddings using the configured model.
-- Delegate search to `FaissStore` and return ranked document IDs.
+ - Delegate search to `FaissStore` and return ranked document filenames using `id_map.json`.
 - Provide an easy-to-mock layer for CLI and future agent use.
 - Detect index dimension at init and switch embedding model accordingly.
 
@@ -24,7 +24,7 @@
 |-----------|------|------|-------------------|
 | 📥 In | text | str | Search query text |
 | 📥 In | k | int | Number of results to return |
-| 📤 Out | results | List[Tuple[int, float]] | Matching document IDs with scores |
+| 📤 Out | results | List[Tuple[str, float]] | Matching document filenames with scores |
 
 ### 🔗 Dependencies
 - `core.embeddings.embedder.embed_text`
@@ -36,3 +36,4 @@
 - Embedding model is configurable; defaults to OpenAI `text-embedding-3-small`.
 - Agents will call this layer instead of accessing FAISS directly.
 - When no model is specified, the retriever infers one by reading the FAISS index dimension.
+- Uses `id_map.json` to translate FAISS integer IDs back to document filenames.

--- a/purpose_files/core.vectorstore.faiss_store.purpose.md
+++ b/purpose_files/core.vectorstore.faiss_store.purpose.md
@@ -12,6 +12,7 @@
 
 # Module: core.vectorstore.faiss_store
 > Lightweight wrapper around FAISS providing add/search and on-disk persistence.
+> Embedding generation stores a JSON map of `{int_id: doc_id}` alongside the index for lookup.
 
 ### 🎯 Intent & Responsibility
 - Manage an inner-product FAISS index keyed by document IDs.
@@ -19,6 +20,7 @@
 - Load existing indexes from disk on initialization.
 - Accepts a `dim` parameter and warns if a stored index exists with a different
   dimension.
+- Numeric IDs are resolved back to filenames via `id_map.json` written by the embedding step.
 
 ### 📥 Inputs & 📤 Outputs
 | Direction | Name  | Type | Brief Description |


### PR DESCRIPTION
## Summary
- use `hashlib.blake2b` to derive stable integer ids
- persist `{int_id: doc_id}` mapping alongside FAISS index
- load the map in `Retriever` and return filenames from search
- document id map behavior in the relevant purpose files

## Testing
- `ruff check src/core/embeddings/embedder.py src/core/retrieval/retriever.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686c0950bdd08323a8e809874fc363ba