### PR TITLE
Add HDBSCAN topic segmentation

### DIFF
--- a/purpose_files/core.parsing.topic_segmenter.purpose.md
+++ b/purpose_files/core.parsing.topic_segmenter.purpose.md
@@ -1,0 +1,39 @@
+- @ai-path: core.parsing.topic_segmenter
+- @ai-source-file: topic_segmenter.py
+- @ai-role: analysis.utility
+- @ai-intent: "Detect topic shifts in text using UMAP + HDBSCAN over window embeddings."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+- @schema-version: 0.2
+- @ai-risk-pii: low
+- @ai-risk-performance: "Embedding and clustering can be slow on long documents."
+
+# Module: core.parsing.topic_segmenter
+> Identify topical boundaries in documents with density-based clustering.
+
+### 🎯 Intent & Responsibility
+- Slide a fixed-size window over tokenized text and embed each slice.
+- Reduce embedding dimensions with UMAP.
+- Cluster windows via HDBSCAN; boundaries form when cluster IDs change.
+- Provide optional parameter hooks for UMAP/HDBSCAN configuration.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | text | str | Raw text to segment |
+| 📥 In | window_tokens | int | Token count for each embedding window |
+| 📥 In | step_tokens | int | Step size between window starts |
+| 📥 In | cluster_method | str | Clustering algorithm; currently only `"hdbscan"` |
+| 📥 In | model | str | Embedding model name |
+| 📤 Out | segments | List[Dict[str, Any]] | Segment dicts with `text`, `start`, `end`, `cluster_id` |
+
+### 🔗 Dependencies
+- `tiktoken`, `umap-learn`, `hdbscan`
+- `core.embeddings.embedder.embed_text`
+- `core.utils.logger.get_logger`
+
+### 🗣 Dialogic Notes
+- Noise points (`cluster_id = -1`) simply propagate as separate segments.
+- Future versions may support additional clustering methods or heuristics.

--- a/src/core/parsing/__init__.py
+++ b/src/core/parsing/__init__.py
@@ -1,2 +1,4 @@
 
 from .semantic_chunk import semantic_chunk_text
+
+from .topic_segmenter import segment_topics

--- a/src/core/parsing/topic_segmenter.py
+++ b/src/core/parsing/topic_segmenter.py
@@ -1,0 +1,105 @@
+"""
+Module: core.parsing.topic_segmenter
+- @ai-path: core.parsing.topic_segmenter
+- @ai-source-file: topic_segmenter.py
+- @ai-role: parser
+- @ai-intent: "Detect topic boundaries using UMAP + HDBSCAN over window embeddings."
+"""
+
+from typing import Any, Dict, List, Optional
+
+import hdbscan
+import numpy as np
+import tiktoken
+import umap
+
+from core.embeddings.embedder import embed_text
+from core.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def segment_topics(
+    text: str,
+    window_tokens: int = 200,
+    step_tokens: int = 100,
+    cluster_method: str = "hdbscan",
+    model: str = "text-embedding-3-small",
+    umap_config: Optional[Dict[str, Any]] = None,
+    hdbscan_config: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    """Return topic segments with start/end token indices and cluster IDs."""
+    enc = tiktoken.encoding_for_model(model)
+    tokens = enc.encode(text, disallowed_special=())
+
+    windows: List[List[float]] = []
+    starts: List[int] = []
+    for i in range(0, len(tokens), step_tokens):
+        window = tokens[i : i + window_tokens]
+        if not window:
+            continue
+        window_text = enc.decode(window)
+        vec = embed_text(window_text, model=model)
+        windows.append(vec)
+        starts.append(i)
+
+    if not windows:
+        logger.warning("No windows produced for segmentation")
+        return [
+            {
+                "text": text,
+                "start": 0,
+                "end": len(tokens),
+                "cluster_id": 0,
+            }
+        ]
+
+    logger.info("Embedded %d windows", len(windows))
+
+    X = np.asarray(windows, dtype="float32")
+    reducer = umap.UMAP(
+        **(
+            umap_config
+            or {"n_neighbors": 15, "min_dist": 0.1, "random_state": 42}
+        )
+    )
+    X_red = reducer.fit_transform(X)
+
+    if cluster_method != "hdbscan":
+        logger.warning("Unsupported cluster_method %s; using hdbscan", cluster_method)
+
+    clusterer = hdbscan.HDBSCAN(
+        **(hdbscan_config or {"min_cluster_size": 2})
+    )
+    labels = clusterer.fit_predict(X_red)
+
+    logger.info(
+        "HDBSCAN found %d clusters", len(set(labels)) - (1 if -1 in labels else 0)
+    )
+
+    segments: List[Dict[str, Any]] = []
+    current_start = 0
+    current_label = int(labels[0])
+    for idx in range(1, len(starts)):
+        if int(labels[idx]) != current_label:
+            segments.append(
+                {
+                    "text": enc.decode(tokens[current_start : starts[idx]]),
+                    "start": current_start,
+                    "end": starts[idx],
+                    "cluster_id": current_label,
+                }
+            )
+            current_start = starts[idx]
+            current_label = int(labels[idx])
+
+    segments.append(
+        {
+            "text": enc.decode(tokens[current_start: len(tokens)]),
+            "start": current_start,
+            "end": len(tokens),
+            "cluster_id": current_label,
+        }
+    )
+
+    return segments


### PR DESCRIPTION
## Summary
- implement `segment_topics` using window embeddings, UMAP, and HDBSCAN
- expose new helper in `core.parsing` package
- describe module behavior and IO schema in purpose file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2dc914348323ae54e22b04a0c53d