### PR TITLE
Add topic segmentation tests and logging notes

### DIFF
--- a/purpose_files/core.utils.logger.purpose.md
+++ b/purpose_files/core.utils.logger.purpose.md
@@ -24,3 +24,5 @@
 ### 🗣 Dialogic Notes
 - Called by `core.embeddings.embedder` for detailed error reporting.
 - Additional modules may import this to standardize logging.
+- Used by `core.parsing.semantic_chunk` to emit boundary details when
+  LOG_LEVEL is set to DEBUG.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --maxfail=1 --disable-warnings -q
+testpaths = src/tests

--- a/src/core/parsing/semantic_chunk.py
+++ b/src/core/parsing/semantic_chunk.py
@@ -5,6 +5,9 @@ from sklearn.cluster import KMeans
 import tiktoken
 
 from core.embeddings.embedder import embed_text
+from core.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def semantic_chunk_text(
@@ -17,6 +20,7 @@ def semantic_chunk_text(
     """Segment ``text`` using window embeddings and KMeans clustering."""
     enc = tiktoken.encoding_for_model(model)
     tokens = enc.encode(text, disallowed_special=())
+    logger.debug("Tokenized into %d tokens", len(tokens))
 
     windows = []
     starts = []
@@ -28,21 +32,25 @@ def semantic_chunk_text(
         vec = embed_text(window_text, model=model)
         windows.append(vec)
         starts.append(i)
+    logger.debug("Created %d windows", len(windows))
     if not windows:
         return [text]
 
     X = np.asarray(windows, dtype="float32")
     km = KMeans(n_clusters=min(n_clusters, len(windows)), n_init="auto")
     labels = km.fit_predict(X)
+    logger.debug("Window labels: %s", labels.tolist())
 
     boundaries = [0]
     for idx in range(1, len(labels)):
         if labels[idx] != labels[idx - 1]:
             boundaries.append(starts[idx])
     boundaries.append(len(tokens))
+    logger.debug("Detected boundaries at %s", boundaries)
 
     chunks = []
     for a, b in zip(boundaries[:-1], boundaries[1:]):
         chunk_tokens = tokens[a:b]
         chunks.append(enc.decode(chunk_tokens))
+    logger.debug("Produced %d chunks", len(chunks))
     return chunks

--- a/src/tests/test_clustering_from_embeddings.py
+++ b/src/tests/test_clustering_from_embeddings.py
@@ -11,9 +11,11 @@ from core.clustering.clustering_steps import (
     run_export,
     run_labeling,
 )
+from core.workflows.main_commands import classify
+from core.config.path_config import PathConfig
 
 
-def test_clustering_from_embeddings():
+def test_clustering_from_embeddings(tmp_path, monkeypatch):
     print("🧪 Testing clustering from existing embeddings...")
     paths = get_path_config()
     embedding_path = paths.root / "rich_doc_embeddings.json"
@@ -35,6 +37,38 @@ def test_clustering_from_embeddings():
     labels = run_clustering(X, method="spectral")
     label_map = run_labeling(doc_ids, labels, metadata_dir)
     run_export(doc_ids, coords, labels, label_map, out_dir, metadata_dir)
+
+    # exercise classification path on a minimal sample
+    pc = PathConfig(root=tmp_path)
+    pc.parsed.mkdir(parents=True, exist_ok=True)
+    pc.metadata.mkdir(parents=True, exist_ok=True)
+    sample_file = pc.parsed / "sample.txt"
+    sample_file.write_text("Cats purr. " * 20 + "Dogs bark. " * 20)
+
+    monkeypatch.setattr(
+        "core.config.config_registry.get_path_config", lambda: pc
+    )
+    monkeypatch.setattr(
+        "core.parsing.semantic_chunk.embed_text",
+        lambda text, model="text-embedding-3-small": [0.0],
+    )
+    monkeypatch.setattr(
+        "core.workflows.main_commands.summarize_text",
+        lambda text, doc_type="standard": {
+            "summary": text[:10],
+            "topics": ["x"],
+            "tags": [],
+            "themes": [],
+            "priority": 1,
+            "tone": "info",
+            "stage": "draft",
+            "depth": "low",
+            "category": doc_type,
+        },
+    )
+    metadata = classify(sample_file.name, chunked=True)
+    assert isinstance(metadata, dict)
+    assert pc.metadata.joinpath(f"{sample_file.name}.meta.json").exists()
 
     assert out_dir.joinpath("cluster_map.json").exists()
     assert out_dir.joinpath("cluster_labels.json").exists()

--- a/src/tests/test_topic_segmenter.py
+++ b/src/tests/test_topic_segmenter.py
@@ -1,0 +1,51 @@
+import os
+import logging
+import sys
+from pathlib import Path
+import pytest
+
+import types
+
+sys.modules.setdefault(
+    "faiss",
+    types.SimpleNamespace(
+        IndexIDMap=object,
+        IndexFlatIP=object,
+        write_index=lambda *a, **k: None,
+        read_index=lambda *a, **k: None,
+    ),
+)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tiktoken
+from core.parsing.semantic_chunk import semantic_chunk_text
+
+
+def stub_embed_text(text: str, model: str = "text-embedding-3-small"):
+    if "Cats" in text:
+        return [0.0]
+    return [10.0]
+
+
+def test_boundary_detection_and_logging(monkeypatch, caplog):
+    os.environ["LOG_LEVEL"] = "DEBUG"
+    class DummyEncoding:
+        def encode(self, text, disallowed_special=()):
+            return text.split()
+
+        def decode(self, tokens):
+            return " ".join(tokens)
+
+    monkeypatch.setattr(tiktoken, "encoding_for_model", lambda model: DummyEncoding())
+    monkeypatch.setattr("core.parsing.semantic_chunk.embed_text", stub_embed_text)
+    sample_text = ("Cats purr. " * 20) + ("Python codes. " * 20)
+    with caplog.at_level(logging.DEBUG):
+        chunks = semantic_chunk_text(
+            sample_text,
+            window_tokens=10,
+            step_tokens=5,
+            n_clusters=2,
+        )
+    assert len(chunks) >= 2
+    assert "Cats" in chunks[0]
+    assert "Python" in chunks[-1]
+    assert any("Detected boundaries" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add debug logging to `semantic_chunk_text`
- ensure pytest only runs files in `src/tests`
- extend heavy clustering test with classification stub path
- add new `test_topic_segmenter` covering boundary detection and logging
- document logger usage in purpose file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2dd3f2f483238b8e2f697b80ad2a