### PR TITLE
Fix embedding workflow after merge

### DIFF
--- a/purpose_files/core.embeddings.embedder.purpose.md
+++ b/purpose_files/core.embeddings.embedder.purpose.md
@@ -23,6 +23,8 @@
 | 📥 In | source_dir | Path | Directory containing text or `.meta.json` files |
 | 📥 In | method | Literal[str] | How to select text (`"parsed"`, `"raw"`, `"summary"`, `"meta"`) |
 | 📥 In | model | str | OpenAI model name |
+| 📥 In | segment_mode | bool | If true, split docs via `topic_segmenter` and embed each chunk |
+| 📥 In | chunk_dir | Path (optional) | Where to write chunk text when `segment_mode` is enabled |
 | 📤 Out | rich_doc_embeddings.json | JSON file of `{doc_id: vector}` |
 | 📤 Out | mosaic.index | FAISS index persisted to disk |
 | 📤 Out | id_map.json | Map of int IDs to original filenames |
@@ -37,3 +39,5 @@
 - Document IDs are hashed via Blake2b and **masked to 63 bits** (`0x7FFF_FFFF_FFFF_FFFF`) so FAISS can store them as signed `int64` without overflow.
 - Embeddings for long documents are averaged from token chunks.
 - FAISS index is recreated on each run if dimensions mismatch.
+- Topic segmentation import is lazy to avoid circular dependencies with
+  `semantic_chunk_text`.


### PR DESCRIPTION
## Summary
- resolve circular import in embedder
- re-add missing vector calculation for non-segmented docs
- document new segmentation options in embedder purpose file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c29f413088323a2675436056d1185