### PR TITLE
Add semantic chunking config flag

### DIFF
--- a/purpose_files/core.embeddings.embedder.purpose.md
+++ b/purpose_files/core.embeddings.embedder.purpose.md
@@ -23,7 +23,7 @@
 | 📥 In | source_dir | Path | Directory containing text or `.meta.json` files |
 | 📥 In | method | Literal[str] | How to select text (`"parsed"`, `"raw"`, `"summary"`, `"meta"`) |
 | 📥 In | model | str | OpenAI model name |
-| 📥 In | segment_mode | bool | If true, split docs via `topic_segmenter` and embed each chunk |
+| 📥 In | segment_mode | bool | Overrides config to use topic segmentation when True; defaults to `PathConfig.semantic_chunking` |
 | 📥 In | chunk_dir | Path (optional) | Where to write chunk text when `segment_mode` is enabled |
 | 📤 Out | rich_doc_embeddings.json | JSON file of `{doc_id: vector}` |
 | 📤 Out | mosaic.index | FAISS index persisted to disk |
@@ -41,3 +41,5 @@
 - FAISS index is recreated on each run if dimensions mismatch.
 - Topic segmentation import is lazy to avoid circular dependencies with
   `semantic_chunk_text`.
+- If `segment_mode` is omitted, `PathConfig.semantic_chunking` determines whether
+  to segment via topics or simple paragraphs.

--- a/purpose_files/core_config_combined.purpose.md
+++ b/purpose_files/core_config_combined.purpose.md
@@ -29,3 +29,4 @@
 - Both `PathConfig` and `RemoteConfig` enforce structure but can be extended to support `.env`, CLI args, or dynamic reloading.
 - This system separates runtime configuration concerns from hardcoded constants, enabling safe parallel use across local and cloud environments.
 - New path entry `vector` will store FAISS index files alongside other outputs.
+- Boolean `semantic_chunking` toggles topic segmentation for embedding generation.

--- a/purpose_files/scripts.pipeline.purpose.md
+++ b/purpose_files/scripts.pipeline.purpose.md
@@ -30,5 +30,6 @@
 - This is the operational entry point for batch processing; ideal for CLI runners, cron jobs, or one-off runs.
 - Handles exceptions gracefully at each step; doesn’t halt pipeline on single failure.
 - Embedding method can be aligned with downstream semantic search or classification heuristics.
+- Embedding segmentation now respects `PathConfig.semantic_chunking` for topic vs. paragraph mode.
 - Could be expanded to support logging, dry-run mode, or parallel processing.
 - When embeddings are generated, vectors are simultaneously added to the FAISS index for immediate searchability.

--- a/src/cli/embed.py
+++ b/src/cli/embed.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import typer
 
 from core.embeddings.embedder import generate_embeddings
+from core.config.config_registry import get_path_config
 
 app = typer.Typer()
 
@@ -14,5 +15,5 @@ def all(
 ):
     """
     Generate embeddings from parsed text, summaries, or raw content.
-    """
-    generate_embeddings(method=method, out_path=out_path)
+    """    paths = get_path_config()
+    generate_embeddings(method=method, out_path=out_path, segment_mode=paths.semantic_chunking)

--- a/src/core/config/path_config.json
+++ b/src/core/config/path_config.json
@@ -5,5 +5,6 @@
   "metadata": "metadata",
   "output": "output",
   "vector": "vector",
-  "schema": "metadata_schema.json"
+  "schema": "metadata_schema.json",
+  "semantic_chunking": false
 }

--- a/src/core/config/path_config.py
+++ b/src/core/config/path_config.py
@@ -54,6 +54,7 @@ class PathConfig:
         output: Union[str, Path] = None,
         vector: Union[str, Path] = None,
         schema: Union[str, Path] = None,
+        semantic_chunking: bool = False,
     ):
         # Use the root provided (do not resolve relative to codebase)
         self.root = Path(root).expanduser().resolve() if root else Path(".").resolve()
@@ -63,6 +64,7 @@ class PathConfig:
         self.output = self._resolve_path_relative_to_root(output, default="output")
         self.vector = self._resolve_path_relative_to_root(vector, default="vector")
         self.schema = self._resolve_path_relative_to_root(schema, default="config/metadata_schema.json")
+        self.semantic_chunking = bool(semantic_chunking)
 
     def __repr__(self):
         return (
@@ -73,6 +75,7 @@ class PathConfig:
             f"OUTPUT:   {self.output}\n"
             f"VECTOR:   {self.vector}\n"
             f"SCHEMA:   {self.schema}\n"
+            f"SEMANTIC_CHUNKING: {self.semantic_chunking}\n"
         )
 
     def _resolve_path_relative_to_root(self, path_value, default):
@@ -112,5 +115,6 @@ class PathConfig:
             metadata=config.get("metadata"),
             output=config.get("output"),
             vector=config.get("vector"),
-            schema=config.get("schema")
+            schema=config.get("schema"),
+            semantic_chunking=config.get("semantic_chunking", False)
         )

--- a/src/core/embeddings/embedder.py
+++ b/src/core/embeddings/embedder.py
@@ -55,7 +55,7 @@ def generate_embeddings(
     method: Literal["parsed", "summary", "raw", "meta"] = "parsed",
     out_path: Path = Path("rich_doc_embeddings.json"),
     model: str = "text-embedding-3-large",
-    segment_mode: bool = False,
+    segment_mode: bool | None = None,
     chunk_dir: Path | None = None,
 ) -> None:
     """Generate embeddings for documents or topic segments.
@@ -66,6 +66,7 @@ def generate_embeddings(
     ``"docID_chunkXX"`` and optionally written to ``chunk_dir``.
     """
     paths = get_path_config()
+    segment_mode = paths.semantic_chunking if segment_mode is None else segment_mode
     source_dir = source_dir or paths.parsed
     out_path = out_path or paths.vector / "rich_doc_embeddings.json"
     embeddings: Dict[str, List[float]] = {}
@@ -78,8 +79,6 @@ def generate_embeddings(
     store = FaissStore(dim=index_dim, path=index_path)
 
     chunk_dir = chunk_dir or (paths.vector / "chunks")
-    if segment_mode:
-        chunk_dir.mkdir(parents=True, exist_ok=True)
 
     for file in sorted(source_dir.glob("*.txt" if method != "meta" else "*.meta.json")):
         doc_id = file.stem
@@ -106,22 +105,28 @@ def generate_embeddings(
             if segment_mode:
                 from core.parsing.topic_segmenter import topic_segmenter
                 segments = topic_segmenter(text, model=model)
-                for idx, chunk in enumerate(segments):
-                    seg_id = f"{doc_id}_chunk{idx:02d}"
-                    vector = embed_text(chunk, model=model)
-                    embeddings[seg_id] = vector
-                    hashed = store.add([seg_id], [vector])[0]
-                    id_map[str(hashed)] = seg_id
-                    (chunk_dir / f"{seg_id}.txt").write_text(chunk, encoding="utf-8")
             else:
-                vector = embed_text(text, model=model)
+                from core.parsing.chunk_text import chunk_text
+                segments = chunk_text(text)
+
+            if len(segments) == 1 and not segment_mode:
+                vector = embed_text(segments[0], model=model)
                 embeddings[doc_id] = vector
                 hashed_id = int.from_bytes(
                     hashlib.blake2b(doc_id.encode("utf-8"), digest_size=8).digest(),
                     "big",
-                ) & 0x7FFF_FFFF_FFFF_FFFF  # truncate to 63 bits for FAISS
+                ) & 0x7FFF_FFFF_FFFF_FFFF
                 store.add([hashed_id], [vector])
                 id_map[str(hashed_id)] = doc_id
+            else:
+                chunk_dir.mkdir(parents=True, exist_ok=True)
+                for idx, chunk in enumerate(segments):
+                    seg_id = f"{doc_id}_chunk{idx:02d}"
+                    vector = embed_text(chunk, model=model)
+                    embeddings[seg_id] = vector
+                    hashed = store.add([seg_id], [vector])[0] & 0x7FFF_FFFF_FFFF_FFFF
+                    id_map[str(hashed)] = seg_id
+                    (chunk_dir / f"{seg_id}.txt").write_text(chunk, encoding="utf-8")
         except Exception:
             logger.exception("Failed embedding %s", file.name)
 

--- a/src/scripts/pipeline.py
+++ b/src/scripts/pipeline.py
@@ -48,5 +48,5 @@ def run_full_pipeline(
             print(f"❌ Classification failed: {name} — {e}")
 
     print("📊 Generating embeddings and updating vector index...")
-    generate_embeddings(method=method)
+    generate_embeddings(method=method, segment_mode=paths.semantic_chunking)
     print("✅ Pipeline complete.")


### PR DESCRIPTION
## Summary
- extend `PathConfig` to include `semantic_chunking` boolean
- route embedding generation and CLI wrappers through this new flag
- update `path_config.json` and document new option
- mention new behavior in embedder and pipeline purpose docs

## Testing
- `pip install -r requirements.txt`
- `pip install tiktoken`
- `pip install faiss-cpu`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4db3f8cc832386dde4238289906f