### PR TITLE
Add Section 9 pipeline integration notes

### DIFF
--- a/purpose_files/cli_combined.purpose.md
+++ b/purpose_files/cli_combined.purpose.md
@@ -40,3 +40,9 @@
 - `search` accepts a natural language query and returns document IDs ranked by semantic similarity.
 - `agent` orchestrates cooperative roles such as Synthesizer and Insight Aggregator while respecting a budget cap.
 - Classification commands now accept `--segmentation` to switch between semantic or paragraph chunking.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: inverse
+- **Coordination Mechanics:** CLI commands orchestrate uploads, segmentation, embedding, and retrieval through underlying workflow modules.
+- **Integration Points:** Invokes `core.workflows.main_commands`, `core.embeddings.embedder`, and leverages Retriever and Synthesizer agents plus TokenMap Analyzer outputs.
+- **Risks:** Mismatched CLI flags may bypass segmentation; large batch operations can exceed API budget.

--- a/purpose_files/core.embeddings.embedder.purpose.md
+++ b/purpose_files/core.embeddings.embedder.purpose.md
@@ -45,3 +45,9 @@
 - If `segment_mode` is omitted, `PathConfig.semantic_chunking` determines whether
   to segment via topics or simple paragraphs.
 - Estimated OpenAI cost is checked via `BudgetTracker`; calls abort when the budget is exceeded.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: inverse
+- **Coordination Mechanics:** Embedding generation triggers semantic chunking when enabled and writes vectors to `FaissStore`. Index files are then consumed by `core.retrieval.retriever`.
+- **Integration Points:** Downstream usage includes Retriever search, Synthesizer summarization loops, and TokenMap Analyzer for chunk metrics.
+- **Risks:** Excessive chunk count inflates API spend and FAISS index size; GPU memory may limit batch processing.

--- a/purpose_files/core.parsing.combined.purpose.md
+++ b/purpose_files/core.parsing.combined.purpose.md
@@ -32,3 +32,9 @@
 - Future extensions could add support for HTML/EPUB and fallback token-based chunking for edge cases.
 - New `semantic_chunk_text` function performs window embedding, clustering, and boundary detection to create topic-coherent segments.
 - `topic_segmenter` combines `semantic_chunk_text` with paragraph fallback for embedding workflows.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: inverse
+- **Coordination Mechanics:** Parsing functions supply normalized filenames and semantic chunks consumed by `core.embeddings.embedder`.
+- **Integration Points:** Outputs route through `core.retrieval.retriever` and Synthesizer modules; TokenMap Analyzer uses chunk metadata.
+- **Risks:** Mis-segmented text may degrade embedding quality; large files increase clustering cost.

--- a/purpose_files/core.parsing.semantic_chunk.purpose.md
+++ b/purpose_files/core.parsing.semantic_chunk.purpose.md
@@ -35,3 +35,9 @@
 ### 🗣 Dialogic Notes
 - Works best when text length >> window size, giving enough context for clustering.
 - Future improvements might use HDBSCAN or heuristics to auto-select cluster count.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: inverse
+- **Coordination Mechanics:** Called by `core.embeddings.embedder` when `segment_mode=True`; outputs are written to disk and embedded for vector search.
+- **Integration Points:** Results feed into `core.retrieval.retriever`, `core.synthesizer` workflows, and TokenMap Analyzer.
+- **Risks:** Overclustering can fragment context, while excessive window count drives GPU and API cost.

--- a/purpose_files/core.parsing.topic_segmenter.purpose.md
+++ b/purpose_files/core.parsing.topic_segmenter.purpose.md
@@ -43,3 +43,9 @@
 - Future versions may support additional clustering methods or heuristics
 - Designed for embedding generation when `segment_mode` is enabled.
 - Keeps segments small and coherent for improved retrieval granularity.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: inverse
+- **Coordination Mechanics:** Invoked by embedding workflows when topic segmentation is requested. Segment dicts are persisted and passed to downstream embedding and summarization steps.
+- **Integration Points:** Downstream modules include `core.retrieval.retriever`, document Synthesizer routines, and TokenMap Analyzer for segment indexing.
+- **Risks:** UMAP/HDBSCAN parameters may overcluster or generate noise points, increasing GPU cost and fragmenting retrieval.

--- a/purpose_files/core.retrieval.retriever.purpose.md
+++ b/purpose_files/core.retrieval.retriever.purpose.md
@@ -40,3 +40,9 @@
 - When no model is specified, the retriever infers one by reading the FAISS index dimension.
 - Uses `id_map.json` to translate FAISS integer IDs back to document filenames.
 - When embeddings include chunk IDs (`doc_chunk01`), results may refer to those composite identifiers and `return_text` can load the chunk file if available.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: inverse
+- **Coordination Mechanics:** Receives query embeddings from `embed_text` and consults `FaissStore`; optionally loads chunk text for Synthesizer steps.
+- **Integration Points:** Results feed directly into the Synthesizer RAG loop and TokenMap Analyzer for token-level context alignment.
+- **Risks:** Retrieval across many chunks may load large text blobs and increase latency; misaligned embeddings reduce search quality.

--- a/purpose_files/core.vectorstore.faiss_store.purpose.md
+++ b/purpose_files/core.vectorstore.faiss_store.purpose.md
@@ -41,3 +41,9 @@
 ### 🗣 Dialogic Notes
 - Designed as a swap-in component for alternative stores like Qdrant or Milvus.
 - Future enhancement: write-ahead log for crash-safe incremental indexing.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: inverse
+- **Coordination Mechanics:** `FaissStore` persists embeddings from the embedder and provides search to the Retriever. Index dimension guides model selection.
+- **Integration Points:** Used by `core.embeddings.embedder`, `core.retrieval.retriever`, and TokenMap Analyzer for vector lookups.
+- **Risks:** Large indexes consume disk and RAM; mismatched dimensions cause search failures.

--- a/purpose_files/core_embeddings_combined.purpose.md
+++ b/purpose_files/core_embeddings_combined.purpose.md
@@ -41,3 +41,9 @@
 - Logging now handled via `core.utils.logger`; failures emit stack traces for easier debugging.
 - The FAISS index is reinitialized each run to avoid dimension mismatches.
 - When `segment_mode` is enabled, each topic chunk is embedded separately and stored under composite IDs like `doc_chunk01`.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: inverse
+- **Coordination Mechanics:** Embedding loader and generator interact with `FaissStore` and optionally call `topic_segmenter` before vectorizing.
+- **Integration Points:** Outputs are used by `core.retrieval.retriever`, RAG Synthesizer steps, and TokenMap Analyzer for mapping tokens to chunks.
+- **Risks:** Large embedding matrices may exceed available memory; over-segmentation increases runtime and storage.

--- a/purpose_files/core_workflows_main_commands.purpose.md
+++ b/purpose_files/core_workflows_main_commands.purpose.md
@@ -34,3 +34,9 @@
 - `pipeline_from_upload()` provides a single-call ingestion-to-metadata interface.
 - Works with either local-only or hybrid S3-local workflows.
 - Meant to decouple CLI and backend logic, enabling reuse in batch processing or UIs.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: inverse
+- **Coordination Mechanics:** Wraps parsing, topic segmentation, summarization, and embedding into a single flow. Metadata output guides downstream retrieval and synthesis.
+- **Integration Points:** Relies on `core.parsing.topic_segmenter`, `core.embeddings.embedder`, and feeds results to Retriever and Synthesizer loops, plus TokenMap Analyzer for audit.
+- **Risks:** Misconfigured segmentation or missing metadata can derail later search and summarization stages; long documents increase OpenAI costs.

--- a/purpose_files/scripts.pipeline.purpose.md
+++ b/purpose_files/scripts.pipeline.purpose.md
@@ -33,3 +33,9 @@
 - Embedding segmentation now respects `PathConfig.semantic_chunking` for topic vs. paragraph mode.
 - Could be expanded to support logging, dry-run mode, or parallel processing.
 - When embeddings are generated, vectors are simultaneously added to the FAISS index for immediate searchability.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: inverse
+- **Coordination Mechanics:** Runs end-to-end steps—upload, parse, segment, summarize, embed—ensuring outputs are synchronized before index update.
+- **Integration Points:** Utilizes `core.embeddings.embedder`, `core.retrieval.retriever`, and passes metadata to Synthesizer and TokenMap Analyzer modules.
+- **Risks:** Pipeline failures at any step can leave partial outputs; large document batches magnify OpenAI costs and GPU usage.


### PR DESCRIPTION
## Summary
- document how semantic chunking components coordinate with downstream modules
- update core purpose files with pipeline order and integration notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5d7cb59083238a7363534e831992