### PR TITLE
Add semantic chunk clustering and enriched embeddings

### DIFF
--- a/purpose_files/core.embeddings.embedder.purpose.md
+++ b/purpose_files/core.embeddings.embedder.purpose.md
@@ -16,6 +16,7 @@
 - Create embeddings for parsed, raw, summary, or metadata text.
 - Insert vectors into `FaissStore` for later retrieval or clustering.
 - Store a JSON map linking hashed IDs to document filenames.
+- When segmenting, persist chunk metadata with embeddings for downstream search.
 
 ### 📥 Inputs & 📤 Outputs
 | Direction | Name | Type | Brief Description |
@@ -28,6 +29,7 @@
 | 📤 Out | rich_doc_embeddings.json | JSON file of `{doc_id: vector}` |
 | 📤 Out | mosaic.index | FAISS index persisted to disk |
 | 📤 Out | id_map.json | Map of int IDs to original filenames |
+| 📤 Out | chunks/*.json | Per-chunk files with text, embedding, and metadata |
 
 ### 🔗 Dependencies
 - `openai`, `tiktoken`, `numpy`
@@ -41,7 +43,7 @@
 - Embeddings for long documents are averaged from token chunks.
 - FAISS index is recreated on each run if dimensions mismatch.
 - Topic segmentation import is lazy to avoid circular dependencies with
-  `semantic_chunk_text`.
+  `semantic_chunk`.
 - If `segment_mode` is omitted, `PathConfig.semantic_chunking` determines whether
   to segment via topics or simple paragraphs.
 - Estimated OpenAI cost is checked via `BudgetTracker`; calls abort when the budget is exceeded.

--- a/purpose_files/core.parsing.semantic_chunk.purpose.md
+++ b/purpose_files/core.parsing.semantic_chunk.purpose.md
@@ -1,7 +1,7 @@
 - @ai-path: core.parsing.semantic_chunk
 - @ai-source-file: semantic_chunk.py
 - @ai-role: analysis.utility
-- @ai-intent: "Segment text using embedding-based window clustering to infer topic boundaries."
+- @ai-intent: "Cluster window embeddings via UMAP/Spectral to produce labeled semantic chunks."
 - @ai-version: 0.1.0
 - @ai-generated: true
 - @ai-verified: false
@@ -14,22 +14,23 @@
 > Produce topic-aware text chunks by embedding overlapping windows and clustering them.
 
 ### 🎯 Intent & Responsibility
-- Sample small windows from text (e.g., 200 tokens sliding by 100).
-- Embed each window with OpenAI and cluster vectors via KMeans.
-- Detect boundaries where cluster assignment changes to yield semantic segments.
+- Slide 256-token windows over the text with stride 128.
+- Embed each window using `text-embedding-3-large`.
+- Reduce dimensions with UMAP and cluster via Spectral Clustering (HDBSCAN fallback).
+- Merge adjacent windows with identical cluster IDs into final chunks.
 
 ### 📥 Inputs & 📤 Outputs
 | Direction | Name | Type | Brief Description |
 |-----------|------|------|-------------------|
 | 📥 In | text | str | Raw document text to segment |
-| 📥 In | window_tokens | int | Size of sliding windows for sampling |
-| 📥 In | step_tokens | int | Step between window starts |
-| 📥 In | n_clusters | int | Number of clusters for KMeans |
-| 📤 Out | chunks | List[str] | Topic-coherent text segments |
+| 📥 In | window_tokens | int | Token count for each window (default 256) |
+| 📥 In | step_tokens | int | Token stride between windows (default 128) |
+| 📥 In | cluster_method | str | "spectral" or "hdbscan" |
+| 📤 Out | chunks | List[Dict[str, Any]] | Chunk objects with `text`, `embedding`, `topic`, `start`, `end`, `cluster_id` |
 
 ### 🔗 Dependencies
 - `tiktoken` for tokenization
-- `sklearn.cluster.KMeans`
+- `umap-learn`, `sklearn.cluster.SpectralClustering`, `hdbscan`
 - `core.embeddings.embedder.embed_text`
 
 ### 🗣 Dialogic Notes

--- a/src/core/parsing/__init__.py
+++ b/src/core/parsing/__init__.py
@@ -1,5 +1,4 @@
 
-from .semantic_chunk import semantic_chunk_text
+from .semantic_chunk import semantic_chunk_text, semantic_chunk
 from .topic_segmenter import segment_text, segment_topics, topic_segmenter
-
-__all__ = ["semantic_chunk_text", "segment_text"]
+__all__ = ["semantic_chunk_text", "semantic_chunk", "segment_text"]

--- a/src/core/parsing/semantic_chunk.py
+++ b/src/core/parsing/semantic_chunk.py
@@ -1,8 +1,10 @@
-from typing import List
+from typing import Any, Dict, List, Sequence
 
 import numpy as np
-from sklearn.cluster import KMeans
 import tiktoken
+import umap
+from sklearn.cluster import SpectralClustering
+import hdbscan
 
 from core.embeddings.embedder import embed_text
 from core.utils.logger import get_logger
@@ -10,20 +12,48 @@ from core.utils.logger import get_logger
 logger = get_logger(__name__)
 
 
-def semantic_chunk_text(
+def _cluster_embeddings(embeddings: Sequence[Sequence[float]], method: str) -> List[int]:
+    """Cluster embeddings using UMAP + Spectral Clustering or HDBSCAN."""
+    X = np.asarray(embeddings, dtype="float32")
+    reducer = umap.UMAP(n_neighbors=15, min_dist=0.1, random_state=42)
+    X_red = reducer.fit_transform(X)
+
+    if method == "spectral":
+        try:
+            n_clusters = max(2, min(10, len(embeddings)))
+            clusterer = SpectralClustering(
+                n_clusters=n_clusters,
+                affinity="nearest_neighbors",
+                assign_labels="discretize",
+                random_state=42,
+            )
+            labels = clusterer.fit_predict(X_red)
+        except Exception:
+            logger.exception("Spectral clustering failed; falling back to HDBSCAN")
+            clusterer = hdbscan.HDBSCAN(min_cluster_size=2)
+            labels = clusterer.fit_predict(X_red)
+    else:
+        clusterer = hdbscan.HDBSCAN(min_cluster_size=2)
+        labels = clusterer.fit_predict(X_red)
+
+    logger.debug("Cluster labels: %s", labels.tolist())
+    return labels.tolist()
+
+
+def semantic_chunk(
     text: str,
-    model: str = "text-embedding-3-small",
-    window_tokens: int = 200,
-    step_tokens: int = 100,
-    n_clusters: int = 5,
-) -> List[str]:
-    """Segment ``text`` using window embeddings and KMeans clustering."""
+    model: str = "text-embedding-3-large",
+    window_tokens: int = 256,
+    step_tokens: int = 128,
+    cluster_method: str = "spectral",
+) -> List[Dict[str, Any]]:
+    """Return semantic chunk objects with embeddings and metadata."""
     enc = tiktoken.encoding_for_model(model)
     tokens = enc.encode(text, disallowed_special=())
     logger.debug("Tokenized into %d tokens", len(tokens))
 
     windows: List[List[float]] = []
-    starts = []
+    starts: List[int] = []
     for i in range(0, len(tokens), step_tokens):
         window = tokens[i : i + window_tokens]
         if not window:
@@ -33,24 +63,56 @@ def semantic_chunk_text(
         windows.append(vec)
         starts.append(i)
     logger.debug("Created %d windows", len(windows))
+
     if not windows:
-        return [text]
+        return [
+            {
+                "text": text,
+                "embedding": embed_text(text, model=model),
+                "topic": "topic_0",
+                "start": 0,
+                "end": len(tokens),
+                "cluster_id": 0,
+            }
+        ]
 
-    X = np.asarray(windows, dtype="float32")
-    km = KMeans(n_clusters=min(n_clusters, len(windows)), n_init="auto")
-    labels = km.fit_predict(X)
-    logger.debug("Window labels: %s", labels.tolist())
+    labels = _cluster_embeddings(windows, cluster_method)
 
-    boundaries = [0]
-    for idx in range(1, len(labels)):
-        if labels[idx] != labels[idx - 1]:
-            boundaries.append(starts[idx])
-    boundaries.append(len(tokens))
-    logger.debug("Detected boundaries at %s", boundaries)
+    segments: List[Dict[str, Any]] = []
+    current_start = 0
+    current_label = labels[0]
+    for idx in range(1, len(starts)):
+        if labels[idx] != current_label:
+            seg_text = enc.decode(tokens[current_start : starts[idx]])
+            segments.append(
+                {
+                    "text": seg_text,
+                    "embedding": embed_text(seg_text, model=model),
+                    "topic": f"topic_{current_label}",
+                    "start": current_start,
+                    "end": starts[idx],
+                    "cluster_id": int(current_label),
+                }
+            )
+            current_start = starts[idx]
+            current_label = labels[idx]
 
-    chunks = []
-    for a, b in zip(boundaries[:-1], boundaries[1:]):
-        chunk_tokens = tokens[a:b]
-        chunks.append(enc.decode(chunk_tokens))
-    logger.debug("Produced %d chunks", len(chunks))
-    return chunks
+    seg_text = enc.decode(tokens[current_start: len(tokens)])
+    segments.append(
+        {
+            "text": seg_text,
+            "embedding": embed_text(seg_text, model=model),
+            "topic": f"topic_{current_label}",
+            "start": current_start,
+            "end": len(tokens),
+            "cluster_id": int(current_label),
+        }
+    )
+
+    logger.debug("Produced %d segments", len(segments))
+    return segments
+
+
+def semantic_chunk_text(*args, **kwargs) -> List[str]:
+    """Compatibility wrapper returning only text chunks."""
+    return [c["text"] for c in semantic_chunk(*args, **kwargs)]

--- a/src/tests/test_embedder_id_mask.py
+++ b/src/tests/test_embedder_id_mask.py
@@ -42,3 +42,35 @@ def test_generate_embeddings_no_overflow(tmp_path, monkeypatch):
     id_map = json.loads(id_map_path.read_text())
     for hashed in id_map.keys():
         assert int(hashed) < 2 ** 63
+
+
+def test_generate_embeddings_with_segments(tmp_path, monkeypatch):
+    paths = PathConfig(root=tmp_path)
+    paths.parsed = tmp_path / "parsed"
+    paths.vector = tmp_path / "vector"
+    paths.parsed.mkdir()
+    paths.vector.mkdir()
+    (paths.parsed / "example.txt").write_text("hello world", encoding="utf-8")
+
+    monkeypatch.setattr(config_registry, "get_path_config", lambda force_reload=False: paths)
+    monkeypatch.setattr(embedder, "get_path_config", lambda force_reload=False: paths)
+
+    dummy_chunk = {
+        "text": "hello world",
+        "embedding": [0.0] * embedder.MODEL_DIMS["text-embedding-3-large"],
+        "topic": "topic_0",
+        "start": 0,
+        "end": 2,
+        "cluster_id": 0,
+    }
+    import importlib
+    sc_module = importlib.import_module("core.parsing.semantic_chunk")
+    monkeypatch.setattr(sc_module, "semantic_chunk", lambda text, model="text-embedding-3-large", **k: [dummy_chunk])
+
+    embedder.generate_embeddings(model="text-embedding-3-large", segment_mode=True)
+
+    chunk_file = paths.vector / "chunks" / "example_chunk00.json"
+    assert chunk_file.exists()
+    data = json.loads(chunk_file.read_text())
+    assert data["text"] == "hello world"
+    assert "embedding" in data

--- a/src/tests/test_topic_segmenter.py
+++ b/src/tests/test_topic_segmenter.py
@@ -17,7 +17,7 @@ sys.modules.setdefault(
 )
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import tiktoken
-from core.parsing.semantic_chunk import semantic_chunk_text
+from core.parsing.semantic_chunk import semantic_chunk
 
 
 def stub_embed_text(text: str, model: str = "text-embedding-3-small"):
@@ -36,16 +36,36 @@ def test_boundary_detection_and_logging(monkeypatch, caplog):
             return " ".join(tokens)
 
     monkeypatch.setattr(tiktoken, "encoding_for_model", lambda model: DummyEncoding())
-    monkeypatch.setattr("core.parsing.semantic_chunk.embed_text", stub_embed_text)
+    import importlib
+    sc_module = importlib.import_module("core.parsing.semantic_chunk")
+    monkeypatch.setattr(sc_module, "embed_text", stub_embed_text)
+    class DummyUMAP:
+        def fit_transform(self, X):
+            return X
+
+    class DummySC:
+        def __init__(self, *a, **k):
+            pass
+
+        def fit_predict(self, X):
+            half = len(X) // 2
+            import numpy as np
+            return np.asarray([0] * half + [1] * (len(X) - half))
+
+    import importlib
+    sc_module = importlib.import_module("core.parsing.semantic_chunk")
+    monkeypatch.setattr(sc_module, "umap", types.SimpleNamespace(UMAP=lambda *a, **k: DummyUMAP()))
+    monkeypatch.setattr(sc_module, "SpectralClustering", DummySC)
+    monkeypatch.setattr(sc_module, "hdbscan", types.SimpleNamespace(HDBSCAN=lambda *a, **k: DummySC()))
+
     sample_text = ("Cats purr. " * 20) + ("Python codes. " * 20)
     with caplog.at_level(logging.DEBUG):
-        chunks = semantic_chunk_text(
+        chunks = semantic_chunk(
             sample_text,
             window_tokens=10,
             step_tokens=5,
-            n_clusters=2,
         )
     assert len(chunks) >= 2
-    assert "Cats" in chunks[0]
-    assert "Python" in chunks[-1]
-    assert any("Detected boundaries" in r.message for r in caplog.records)
+    assert chunks[0]["cluster_id"] == 0
+    assert chunks[-1]["cluster_id"] == 1
+    assert any("segments" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- update semantic chunking algorithm with UMAP+Spectral clustering
- store chunk metadata and embeddings when generating vectors
- adjust tests for new segmentation objects
- document updated semantics in module purpose files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d807323c08323a5169ab3f2f1c3bf