### PR TITLE
Add summarizer and memory bank modules

### DIFF
--- a/purpose_files/core.memory.memory_bank.purpose.md
+++ b/purpose_files/core.memory.memory_bank.purpose.md
@@ -1,0 +1,42 @@
+- @ai-path: core.memory.memory_bank
+- @ai-source-file: memory_bank.py
+- @ai-role: memory
+- @ai-intent: "Persist and recall short text frames for context injection."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+- @schema-version: 0.2
+- @ai-risk-pii: medium
+- @ai-risk-performance: low
+
+# Module: core.memory.memory_bank
+> Minimal persistent storage for conversation or document snippets.
+
+### 🎯 Intent & Responsibility
+- Save text frames to disk with timestamped filenames.
+- Load recent frames for reuse in prompts or analysis.
+- Serve as lightweight memory layer for QAT workflows.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | content | str | Text snippet to store |
+| 📥 In | memory_dir | Path | Folder for frames (optional) |
+| 📥 In | limit | int | Number of frames to load |
+| 📤 Out | path | Path | Saved frame file path |
+| 📤 Out | frames | List[str] | Recent frame contents |
+
+### 🔗 Dependencies
+- `json`, `datetime`, `pathlib.Path`
+- `core.utils.logger`
+
+### 🗣 Dialogic Notes
+- Frames are simple JSON files; external systems may ingest them.
+- High-volume storage may require pruning strategies not yet implemented.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: normal
+- **Coordination Mechanics:** Called after summarization or user actions to persist context. Retrieval functions can inject loaded frames before LLM calls.
+- **Integration Points:** May be used by Livewire or synthesis modules for memory injection. Upstream modules pass text; downstream consumers read returned frames.
+- **Risks:** Saving sensitive text may leak PII if not redacted. Consider encryption for sensitive deployments.

--- a/purpose_files/core.synthesis.summarizer.purpose.md
+++ b/purpose_files/core.synthesis.summarizer.purpose.md
@@ -1,0 +1,43 @@
+- @ai-path: core.synthesis.summarizer
+- @ai-source-file: summarizer.py
+- @ai-role: synthesizer
+- @ai-intent: "Retrieve related documents and return a consolidated summary with source links."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+- @schema-version: 0.2
+- @ai-risk-pii: medium
+- @ai-risk-performance: "Multiple LLM calls per query increase latency and cost."
+
+# Module: core.synthesis.summarizer
+> Utility for linking similar insights and generating a single distillation.
+
+### 🎯 Intent & Responsibility
+- Use `Retriever` to fetch top-k related chunks for a query.
+- Summarize each chunk via `summarize_text` and combine into one summary.
+- Return summary text and list of source identifiers.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | query | str | Search text or question |
+| 📥 In | retriever | Retriever | Retrieval interface |
+| 📥 In | chunk_dir | Path | Directory holding text chunks |
+| 📥 In | k | int | Number of matches to summarize |
+| 📤 Out | result | Dict[str, List[str]] | `{summary: str, sources: [ids...]}` |
+
+### 🔗 Dependencies
+- `core.retrieval.retriever.Retriever`
+- `core.llm.invoke.summarize_text`
+- `core.utils.logger`
+
+### 🗣 Dialogic Notes
+- Designed for small sets of documents; large batches may exceed token limits.
+- Agents may chain this after initial retrieval for deeper synthesis.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: normal
+- **Coordination Mechanics:** Called by higher-level workflows after retrieval. May append outputs to Memory Bank.
+- **Integration Points:** Downstream tools expect `{summary, sources}` dict. Upstream calls supply query text.
+- **Risks:** Summarization quality depends on retrieved text; failures return empty summary.

--- a/purpose_files/core_memory_combined.purpose.md
+++ b/purpose_files/core_memory_combined.purpose.md
@@ -1,0 +1,21 @@
+# Module: core.memory
+> Lightweight memory utilities for saving and recalling conversation frames.
+
+### 🎯 Intent & Responsibility
+- Provide persistent storage for short text snippets.
+- Offer helper functions to recall recent frames for context injection.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | content | str | Frame text to store |
+| 📥 In | limit | int | Number of frames to load |
+| 📤 Out | path | Path | Saved frame path |
+| 📤 Out | frames | List[str] | Loaded frame texts |
+
+### 🔗 Dependencies
+- `json`, `datetime`, `pathlib`
+- `core.utils.logger`
+
+### 🗣 Dialogic Notes
+- Frames can be attached to synthesized outputs for persistent memory.

--- a/purpose_files/core_synthesis_combined.purpose.md
+++ b/purpose_files/core_synthesis_combined.purpose.md
@@ -1,0 +1,28 @@
+# Module: core.synthesis
+> Tools for document-level synthesis and insight linking.
+
+### 🎯 Intent & Responsibility
+- Summarize retrieved text using OpenAI models.
+- Consolidate related documents into single distilled outputs.
+- Provide simple interfaces for higher-level workflows to request aggregated insights.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | query | str | Search or question text |
+| 📥 In | retriever | Retriever | Retrieval component |
+| 📤 Out | summary_data | Dict[str, List[str]] | Combined summary and source IDs |
+
+### 🔗 Dependencies
+- `core.llm.invoke.summarize_text`
+- `core.retrieval.retriever.Retriever`
+- `core.utils.logger`
+
+### ⚙️ AI-Memory Tags
+- `@ai-assumes:` LLM APIs accessible and retriever configured.
+- `@ai-breakage:` Missing chunks or API failures yield empty summaries.
+- `@ai-risks:` Summaries may surface sensitive content; use memory guardrails when needed.
+
+### 🗣 Dialogic Notes
+- Designed as a thin synthesis layer feeding more complex agents or UIs.
+- Will integrate with Memory Bank for persistent insight injection.

--- a/src/core/memory/__init__.py
+++ b/src/core/memory/__init__.py
@@ -1,0 +1,1 @@
+from .memory_bank import save_frame, load_recent_frames

--- a/src/core/memory/memory_bank.py
+++ b/src/core/memory/memory_bank.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from core.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_MEMORY_DIR = Path("memory_frames")
+
+
+def save_frame(content: str, memory_dir: Path = DEFAULT_MEMORY_DIR) -> Path:
+    """Persist a text frame for later recall."""
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    path = memory_dir / f"frame_{ts}.json"
+    data = {"timestamp": ts, "content": content}
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    logger.debug("Saved frame %s", path)
+    return path
+
+
+def load_recent_frames(limit: int = 5, memory_dir: Path = DEFAULT_MEMORY_DIR) -> List[str]:
+    """Load recent frames for context injection."""
+    if not memory_dir.exists():
+        return []
+    files = sorted(memory_dir.glob("frame_*.json"), reverse=True)[:limit]
+    frames = []
+    for p in files:
+        try:
+            frames.append(json.loads(p.read_text(encoding="utf-8"))['content'])
+        except Exception as e:
+            logger.warning("Failed to load frame %s: %s", p, e)
+    return frames

--- a/src/core/synthesis/__init__.py
+++ b/src/core/synthesis/__init__.py
@@ -1,0 +1,1 @@
+from .summarizer import summarize_and_link

--- a/src/core/synthesis/summarizer.py
+++ b/src/core/synthesis/summarizer.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from typing import List, Dict
+
+from core.retrieval.retriever import Retriever
+from core.llm.invoke import summarize_text
+from core.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def summarize_and_link(query: str, retriever: Retriever, chunk_dir: Path, k: int = 4) -> Dict[str, List[str]]:
+    """Retrieve related chunks for a query and return a combined summary."""
+    results = retriever.search(query, k=k, chunk_dir=chunk_dir, return_text=True)
+    if not results:
+        return {"summary": "", "sources": []}
+
+    summaries = []
+    sources = []
+    for doc_id, score, text in results:
+        try:
+            data = summarize_text(text)
+            summaries.append(data.get("summary", ""))
+            sources.append(doc_id)
+        except Exception as e:
+            logger.warning("Summary failed for %s: %s", doc_id, e)
+    combined = "\n".join(summaries)
+    if combined:
+        combined = summarize_text(combined).get("summary", combined)
+    return {"summary": combined, "sources": sources}


### PR DESCRIPTION
## Summary
- add synthesis module for summarizing retrieved text and linking sources
- implement lightweight memory bank for saving and recalling frames
- document new modules with purpose files
- aggregate new synthesis and memory groups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8822aec4832398466057de360bc2