### PR TITLE
Implement ChatGPT export parser

### DIFF
--- a/purpose_files/core.parsing.openai_export.purpose.md
+++ b/purpose_files/core.parsing.openai_export.purpose.md
@@ -1,0 +1,41 @@
+# Module: core.parsing.openai_export
+- @ai-path: core.parsing.openai_export
+- @ai-source-file: openai_export.py
+- @ai-role: parser
+- @ai-intent: "Parse ChatGPT Data Export zip to extract conversation transcripts and user prompts."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+- @schema-version: 0.2
+- @ai-risk-pii: high
+- @ai-risk-performance: low
+
+> Processes the `conversations.json` file included in OpenAI's user data export and writes each conversation to its own text file along with a prompt-only file.
+
+### 🎯 Intent & Responsibility
+- Load the export archive or folder.
+- Extract conversations in order of `current_node` parent pointers.
+- Save full transcripts and user-only prompts to disk for later analysis.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name         | Type            | Brief Description |
+|-----------|--------------|-----------------|-------------------|
+| 📥 In     | export_path  | Path            | Path to `.zip` export or extracted folder |
+| 📥 In     | out_dir      | Path            | Directory to write conversation and prompt files |
+| 📤 Out    | conversation | Path            | File path for each conversation transcript |
+| 📤 Out    | prompts      | Path            | File path for user prompts only |
+
+### 🔗 Dependencies
+- `zipfile`, `json`, `pathlib`
+- `core.parsing.normalize.normalize_filename`
+
+### 🗣 Dialogic Notes
+- Only linear path from `current_node` is reconstructed; branches are ignored.
+- File names are normalized and truncated to avoid OS issues.
+- Prompts are separated to help detect duplicate questions across chats.
+
+### 9 Pipeline Integration
+- **Coordination Mechanics:** Intended for manual invocation or future CLI command. Outputs may feed indexing or deduplication workflows.
+- **Integration Points:** Downstream modules could ingest these transcripts for embedding or topic analysis.
+- **Risks:** Export contains personal data; handle securely and avoid accidental commits.

--- a/src/core/parsing/__init__.py
+++ b/src/core/parsing/__init__.py
@@ -1,4 +1,9 @@
-
-from .semantic_chunk import semantic_chunk_text, semantic_chunk
+from .semantic_chunk import semantic_chunk_text
 from .topic_segmenter import segment_text, segment_topics, topic_segmenter
-__all__ = ["semantic_chunk_text", "semantic_chunk", "segment_text"]
+from .openai_export import parse_chatgpt_export
+
+__all__ = [
+    "semantic_chunk_text",
+    "segment_text",
+    "parse_chatgpt_export",
+]

--- a/src/core/parsing/openai_export.py
+++ b/src/core/parsing/openai_export.py
@@ -1,0 +1,100 @@
+"""
+📦 Module: core.parsing.openai_export
+- @ai-path: core.parsing.openai_export
+- @ai-source-file: openai_export.py
+- @ai-role: parser
+- @ai-intent: "Parse ChatGPT Data Export zip to extract conversation transcripts and user prompts."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+
+This module reads the `conversations.json` file included in an OpenAI ChatGPT
+"Data Export" archive and writes each conversation to its own text file.
+Additionally, it saves a corresponding file containing only the user messages
+for quick prompt reuse or duplicate detection.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+import zipfile
+
+from .normalize import normalize_filename
+
+
+def _load_conversations(export_path: Path) -> List[Dict]:
+    """Load conversation list from a zip archive or directory."""
+    if export_path.is_dir():
+        conv_path = export_path / "conversations.json"
+        with conv_path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    with zipfile.ZipFile(export_path) as zf:
+        with zf.open("conversations.json") as f:
+            return json.load(f)
+
+
+def _extract_messages(convo: Dict) -> Iterable[Tuple[str, str]]:
+    """Return ordered (role, text) tuples for a conversation."""
+    mapping = convo.get("mapping", {})
+    node_id = convo.get("current_node")
+    path: List[Tuple[str, str]] = []
+    while node_id:
+        node = mapping.get(node_id)
+        if not node:
+            break
+        msg = node.get("message")
+        if msg and msg.get("author", {}).get("role") != "system":
+            role = msg["author"].get("role", "")
+            parts = msg.get("content", {}).get("parts") or []
+            text = "\n".join(parts)
+            path.append((role, text))
+        node_id = node.get("parent")
+    return reversed(path)
+
+
+def parse_chatgpt_export(export_path: Path, out_dir: Path) -> List[Dict[str, Path]]:
+    """Parse conversations and write text + prompt files.
+
+    Parameters
+    ----------
+    export_path: Path
+        Path to the `.zip` export or the extracted folder.
+    out_dir: Path
+        Directory to write conversation and prompt files.
+
+    Returns
+    -------
+    List[Dict[str, Path]]
+        List of dictionaries describing output file paths per conversation.
+    """
+
+    export_path = Path(export_path)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    prompt_dir = out_dir / "prompts"
+    prompt_dir.mkdir(exist_ok=True)
+
+    conversations = _load_conversations(export_path)
+    outputs: List[Dict[str, Path]] = []
+    for idx, convo in enumerate(conversations):
+        title = convo.get("title") or f"conversation_{idx}"
+        slug = normalize_filename(title)[:32]
+        convo_file = out_dir / f"{idx:04d}_{slug}.txt"
+        prompt_file = prompt_dir / f"{idx:04d}_{slug}_prompts.txt"
+
+        lines = []
+        prompts = []
+        for role, text in _extract_messages(convo):
+            clean = text.strip()
+            lines.append(f"{role.upper()}: {clean}")
+            if role == "user":
+                prompts.append(clean)
+
+        convo_file.write_text("\n".join(lines), encoding="utf-8")
+        prompt_file.write_text("\n".join(prompts), encoding="utf-8")
+        outputs.append({"conversation": convo_file, "prompts": prompt_file})
+
+    return outputs

--- a/src/tests/test_openai_export_parser.py
+++ b/src/tests/test_openai_export_parser.py
@@ -1,0 +1,63 @@
+import json
+import zipfile
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from core.parsing.openai_export import parse_chatgpt_export
+
+
+def make_export_zip(tmp_path: Path) -> Path:
+    conversations = [
+        {
+            "title": "Test Chat",
+            "current_node": "3",
+            "mapping": {
+                "1": {
+                    "id": "1",
+                    "parent": None,
+                    "children": ["2"],
+                    "message": {
+                        "author": {"role": "system"},
+                        "content": {"content_type": "text", "parts": ["You are ChatGPT"]},
+                    },
+                },
+                "2": {
+                    "id": "2",
+                    "parent": "1",
+                    "children": ["3"],
+                    "message": {
+                        "author": {"role": "user"},
+                        "content": {"content_type": "text", "parts": ["Hello"]},
+                    },
+                },
+                "3": {
+                    "id": "3",
+                    "parent": "2",
+                    "children": [],
+                    "message": {
+                        "author": {"role": "assistant"},
+                        "content": {"content_type": "text", "parts": ["Hi!"]},
+                    },
+                },
+            },
+        }
+    ]
+    export_zip = tmp_path / "export.zip"
+    with zipfile.ZipFile(export_zip, "w") as zf:
+        zf.writestr("conversations.json", json.dumps(conversations))
+    return export_zip
+
+
+def test_parse_export(tmp_path: Path):
+    export_zip = make_export_zip(tmp_path)
+    out_dir = tmp_path / "out"
+    results = parse_chatgpt_export(export_zip, out_dir)
+    assert len(results) == 1
+    convo_file = out_dir / "0000_test_chat.txt"
+    prompt_file = out_dir / "prompts" / "0000_test_chat_prompts.txt"
+    assert convo_file.exists()
+    assert prompt_file.exists()
+    assert "USER: Hello" in convo_file.read_text()
+    assert prompt_file.read_text().strip() == "Hello"


### PR DESCRIPTION
## Summary
- parse ChatGPT data export archives to conversation and prompt text
- expose `parse_chatgpt_export` function via `core.parsing`
- document new module purpose
- test parsing on a stub export file

## Testing
- `pytest src/tests/test_openai_export_parser.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d994b130c8323ab0f2e8a9caf56f8