### PR TITLE
Add frame store and insight summarizer modules

### DIFF
--- a/intents/2025-06-30__memory_summarizer.intent.md
+++ b/intents/2025-06-30__memory_summarizer.intent.md
@@ -1,0 +1,1 @@
+Added frame_store for lightweight memory injection and insight_summarizer for cross-document summarization. Embedded instructions remain in single QAT-Kit file to avoid Project file limits.

--- a/purpose_files/core.memory.frame_store.purpose.md
+++ b/purpose_files/core.memory.frame_store.purpose.md
@@ -1,0 +1,44 @@
+# Module: core.memory.frame_store
+- @ai-path: core.memory.frame_store
+- @ai-source-file: frame_store.py
+- @ai-role: memory
+- @ai-intent: "Persist and recall lightweight conversation frames for context injection."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+- @schema-version: 0.2
+- @ai-risk-pii: medium
+- @ai-risk-performance: "Frequent disk writes may impact I/O performance on slow storage."
+
+> Maintain a simple directory of JSON files storing text snippets and metadata for later reuse.
+
+### 🎯 Intent & Responsibility
+- Save short text segments and associated metadata as "frames".
+- Load frames by ID for light memory injection into LLM prompts.
+- Enumerate available frames for exploratory workflows.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | text | str | Raw text to store in the frame |
+| 📥 In | metadata | Optional[dict] | Additional context fields |
+| 📥 In | frame_id | Optional[str] | Custom identifier for the frame |
+| 📤 Out | frame_id | str | Generated or provided frame identifier |
+| 📤 Out | frame | dict | Stored frame with text and metadata |
+| 📤 Out | frames | List[str] | Available frame identifiers |
+
+### 🔗 Dependencies
+- `core.config.config_registry.get_path_config`
+- `json`, `pathlib.Path`
+
+### 🗣 Dialogic Notes
+- Designed for ephemeral conversation snippets or summarization outputs.
+- Frames are stored under `PathConfig.output / "frames"`.
+- IDs are auto-incremented if not provided to ensure uniqueness.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: inverse
+- **Coordination Mechanics:** Light memory injection occurs by loading frames before prompt generation. Retrieval modules or Livewire may reference `list_frames()` to suggest context.
+- **Integration Points:** Upstream summarizers or chat loops can call `save_frame()`; downstream orchestrators read frames for context blending.
+- **Risks:** Large numbers of frames may clutter disk space; consider periodic cleanup.

--- a/purpose_files/core.synthesis.insight_summarizer.purpose.md
+++ b/purpose_files/core.synthesis.insight_summarizer.purpose.md
@@ -1,0 +1,39 @@
+# Module: core.synthesis.insight_summarizer
+- @ai-path: core.synthesis.insight_summarizer
+- @ai-source-file: insight_summarizer.py
+- @ai-role: synthesizer
+- @ai-intent: "Aggregate summaries from multiple documents and highlight shared insights."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+- @schema-version: 0.2
+- @ai-risk-pii: low
+- @ai-risk-performance: "Multiple LLM calls may increase latency and cost."
+
+> Utility functions that generate cross-document summaries to surface common themes.
+
+### 🎯 Intent & Responsibility
+- Summarize each document using `core.llm.invoke.summarize_text`.
+- Combine individual summaries into a single overview linking related ideas.
+- Provide a simple API for downstream pipelines to request insight linking.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | docs | List[str] | Raw text documents or segments |
+| 📥 In | model | str | OpenAI model name for summarization |
+| 📤 Out | summary | str | Consolidated overview of shared insights |
+
+### 🔗 Dependencies
+- `core.llm.invoke.summarize_text`
+
+### 🗣 Dialogic Notes
+- Intended as a lightweight synthesizer step after retrieval.
+- Summaries are concatenated and re-summarized to produce a concise insight report.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: inverse
+- **Coordination Mechanics:** Receives raw docs from Retriever or other modules. Outputs feed into Memory frames or downstream write-ups.
+- **Integration Points:** Can be called by Livewire or CLI to synthesize search results. Works with `core.memory.frame_store` for persistence.
+- **Risks:** Large document lists may exceed model context limits; ensure docs are pre-summarized when needed.

--- a/src/core/memory/__init__.py
+++ b/src/core/memory/__init__.py
@@ -1,0 +1,1 @@
+from .frame_store import save_frame, load_frame, list_frames

--- a/src/core/memory/frame_store.py
+++ b/src/core/memory/frame_store.py
@@ -1,0 +1,41 @@
+"""Module: core.memory.frame_store
+Simple JSON-based storage for conversational frames.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional, Dict, Any, List
+
+from core.config.config_registry import get_path_config
+
+
+def _frames_dir() -> Path:
+    paths = get_path_config()
+    frames = paths.output / "frames"
+    frames.mkdir(parents=True, exist_ok=True)
+    return frames
+
+
+def save_frame(text: str, metadata: Optional[Dict[str, Any]] = None, frame_id: Optional[str] = None) -> str:
+    """Persist a text snippet and metadata as a frame file."""
+    frames = _frames_dir()
+    if not frame_id:
+        frame_id = f"frame_{len(list(frames.glob('frame_*.json'))):04d}"
+    data = {"text": text, "metadata": metadata or {}}
+    (frames / f"{frame_id}.json").write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return frame_id
+
+
+def load_frame(frame_id: str) -> Dict[str, Any]:
+    """Load a stored frame by ID."""
+    path = _frames_dir() / f"{frame_id}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"Frame not found: {frame_id}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def list_frames() -> List[str]:
+    """Return all frame IDs present in the store."""
+    return sorted(p.stem for p in _frames_dir().glob('frame_*.json'))

--- a/src/core/synthesis/__init__.py
+++ b/src/core/synthesis/__init__.py
@@ -1,0 +1,1 @@
+from .insight_summarizer import summarize_and_link

--- a/src/core/synthesis/insight_summarizer.py
+++ b/src/core/synthesis/insight_summarizer.py
@@ -1,0 +1,20 @@
+"""Module: core.synthesis.insight_summarizer
+Aggregate and link insights from retrieved documents.
+"""
+from __future__ import annotations
+
+from typing import List
+
+from core.llm.invoke import summarize_text
+
+
+def summarize_and_link(docs: List[str], model: str = "gpt-4") -> str:
+    """Return a joint summary highlighting connections between documents."""
+    summaries = [summarize_text(d).get("summary", "") for d in docs]
+    joined = "\n".join(f"- {s}" for s in summaries if s)
+    prompt = (
+        "Given the following summaries, identify common themes or insights and "
+        "produce a concise overview.\n" + joined
+    )
+    return summarize_text(prompt, doc_type="standard", model=model).get("summary", "")
+


### PR DESCRIPTION
## Summary
- implement `core.memory.frame_store` for light memory injection
- implement `core.synthesis.insight_summarizer` to link related docs
- document new modules with `.purpose.md`
- capture design intent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tiktoken')*

------
https://chatgpt.com/codex/tasks/task_e_686d8822aec4832398466057de360bc2