### PR TITLE
Expose FrameStore and summarize_documents

### DIFF
--- a/purpose_files/core.memory.frame_store.purpose.md
+++ b/purpose_files/core.memory.frame_store.purpose.md
@@ -33,6 +33,8 @@
 ### 🗣 Dialogic Notes
 - Intended for lightweight human-in-the-loop use; not a fully fledged vector DB.
 - Frame IDs are arbitrary strings (e.g., topic names or timestamps).
+- `FrameStore` is also available via `from core.memory import FrameStore` for
+  convenience.
 
 ### 9 Pipeline Integration
 - **Coordination Mechanics:** Used prior to LLM invocation to inject persistent notes or recap summaries.

--- a/purpose_files/core.synthesis.summarizer.purpose.md
+++ b/purpose_files/core.synthesis.summarizer.purpose.md
@@ -32,6 +32,7 @@
 ### 🗣 Dialogic Notes
 - `summarize_documents` gracefully handles missing text; empty retrieval yields empty summary.
 - Designed for chaining with `Retriever` and future `Memory` modules as part of insight synthesis pipelines.
+- Available via `from core.synthesis import summarize_documents` for package-level access.
 
 ### 9 Pipeline Integration
 - **Coordination Mechanics:** Accepts document IDs from search steps; output feeds into higher-level synthesizers or reporting agents.

--- a/src/core/memory/__init__.py
+++ b/src/core/memory/__init__.py
@@ -1,0 +1,6 @@
+"""Public API for the :mod:`core.memory` package."""
+
+from .frame_store import FrameStore
+
+__all__ = ["FrameStore"]
+

--- a/src/core/synthesis/__init__.py
+++ b/src/core/synthesis/__init__.py
@@ -1,0 +1,6 @@
+"""Public API for the :mod:`core.synthesis` package."""
+
+from .summarizer import summarize_documents
+
+__all__ = ["summarize_documents"]
+

--- a/src/tests/test_frame_store.py
+++ b/src/tests/test_frame_store.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src'))
 
-from core.memory.frame_store import FrameStore
+from core.memory import FrameStore
 
 
 def test_save_and_load(tmp_path):

--- a/src/tests/test_summarizer.py
+++ b/src/tests/test_summarizer.py
@@ -11,7 +11,7 @@ sys.modules['faiss'] = DummyFaiss()
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src'))
 
-from core.synthesis.summarizer import summarize_documents
+from core.synthesis import summarize_documents
 from core.retrieval import retriever as retriever_mod
 
 


### PR DESCRIPTION
## Summary
- export `FrameStore` from `core.memory`
- export `summarize_documents` from `core.synthesis`
- document the new exports in purpose files
- update tests to validate import paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc22b08e48323bbebb6b349e3b8f0