### PR TITLE
Add QAT quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Cognitive Scaffold answers these questions using intelligent summarization, rich
 - 🔍 **Organize and explore** based on category, themes, tags, tone, and stage
 - 🧭 **Suggest exploration trails** and semantic connections
 - 🧰 **Export to folders**, metadata files, and future-ready search/RAG systems
+See [docs/QAT_Quickstart.md](docs/QAT_Quickstart.md) for a brief guide to the QAT layout and basic usage.
 
 ---
 

--- a/docs/QAT_Quickstart.md
+++ b/docs/QAT_Quickstart.md
@@ -1,0 +1,33 @@
+# QAT Quickstart Guide
+
+This project uses the **Quasi-Agent Tool (QAT)** layout for modular AI workflows. The root contains several key files:
+
+- `qat_manifest.json` – defines active agents and pipeline modules.
+- `qat_instructions.json` – runtime directives and repository rules.
+- `core_seed.yml` – shared terminology and defaults.
+- `src/` – python source code for the pipeline.
+- `intents/` – transient design notes (`*.intent.md`).
+- `purpose_files/` – stable module contracts (`*.purpose.md`).
+- `docs/` – documentation, including this quickstart.
+
+
+## Minimal Pipeline Example
+
+The snippet below stores a memory frame and generates a summary from document IDs:
+
+```python
+from core.memory.frame_store import FrameStore
+from core.retrieval.retriever import Retriever
+from core.synthesis.summarizer import summarize_documents
+
+store = FrameStore()
+store.save_frame("intro", "These notes will appear before the summary")
+
+retriever = Retriever()
+text_summary = summarize_documents(["doc1", "doc2"], retriever)
+
+combined = store.inject_memory(text_summary, ["intro"])
+print(combined)
+```
+
+This assumes a FAISS index and chunk directory have been built in `src/core/vectorstore`.


### PR DESCRIPTION
## Summary
- create `docs/QAT_Quickstart.md` with a QAT file layout and simple FrameStore example
- link the quickstart from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc230fb6083238d6b11773f3d80b2