### PR TITLE
Add multi-query retrieval with aggregation

### DIFF
--- a/intents/2025-07-09__retriever_multi_query.intent.md
+++ b/intents/2025-07-09__retriever_multi_query.intent.md
@@ -1,0 +1,1 @@
+Enhanced Retriever with query_multi for multi-query search, ranking aggregation, and optional cross-document merging. Updated purpose file accordingly.

--- a/purpose_files/core.retrieval.retriever.purpose.md
+++ b/purpose_files/core.retrieval.retriever.purpose.md
@@ -1,8 +1,8 @@
 - @ai-path: core.retrieval.retriever
 - @ai-source-file: retriever.py
 - @ai-role: logic
-- @ai-intent: "Embed text queries and return top-k document filenames from the vector store."
-- @ai-version: 0.1.0
+- @ai-intent: "Embed one or more queries, rank results, and optionally aggregate chunk text across documents."
+- @ai-version: 0.2.0
 - @ai-generated: true
 - @ai-verified: false
 - @human-reviewed: false
@@ -22,11 +22,13 @@
 ### 📥 Inputs & 📤 Outputs
 | Direction | Name | Type | Brief Description |
 |-----------|------|------|-------------------|
-| 📥 In | text | str | Search query text |
+| 📥 In | text | str | Search query text (via ``query``) |
+| 📥 In | texts | Iterable[str] | Multiple search queries (``query_multi``) |
 | 📥 In | k | int | Number of results to return |
 | 📥 In | chunk_dir | Path (optional) | Directory holding text chunks for retrieval |
 | 📥 In | return_text | bool (optional) | Include chunk text when `chunk_dir` is configured |
-| 📤 Out | results | List[Tuple[str, float]] or List[Tuple[str, float, str]] | Matching IDs and scores, with text when requested |
+| 📥 In | aggregate | bool (optional) | Combine chunks by document when using ``query_multi`` |
+| 📤 Out | results | List[Tuple[str, float]] or List[Tuple[str, float, str]] | Ranked IDs and scores, optionally aggregated with text |
 
 ### 🔗 Dependencies
 - `core.embeddings.embedder.embed_text`
@@ -40,9 +42,10 @@
 - When no model is specified, the retriever infers one by reading the FAISS index dimension.
 - Uses `id_map.json` to translate FAISS integer IDs back to document filenames.
 - When embeddings include chunk IDs (`doc_chunk01`), results may refer to those composite identifiers and `return_text` can load the chunk file if available.
+- `query_multi` merges scores across queries and can group chunks by their document prefix when `aggregate=True`.
 
 ### 9 Pipeline Integration
 - @ai-pipeline-order: inverse
-- **Coordination Mechanics:** Receives query embeddings from `embed_text` and consults `FaissStore`; optionally loads chunk text for Synthesizer steps.
+- **Coordination Mechanics:** Receives query embeddings from `embed_text` and consults `FaissStore`; can merge scores across multiple queries and aggregate retrieved chunk text.
 - **Integration Points:** Results feed directly into the Synthesizer RAG loop and TokenMap Analyzer for token-level context alignment.
 - **Risks:** Retrieval across many chunks may load large text blobs and increase latency; misaligned embeddings reduce search quality.

--- a/src/core/retrieval/__init__.py
+++ b/src/core/retrieval/__init__.py
@@ -1,0 +1,3 @@
+from .retriever import Retriever
+
+__all__ = ["Retriever"]

--- a/src/core/retrieval/retriever.py
+++ b/src/core/retrieval/retriever.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Iterable, List, Tuple, cast
 from pathlib import Path
 import json
 
@@ -11,7 +11,11 @@ from core.utils.logger import get_logger
 
 
 class Retriever:
-    """Embed queries and return top-k document IDs from the FAISS index."""
+    """Embed queries and return ranked document IDs from the FAISS index.
+
+    Supports multi-query search, ranking across results, and optional
+    cross-document text aggregation.
+    """
 
     def __init__(
         self,
@@ -41,14 +45,81 @@ class Retriever:
             self.model = default_model
 
     def query(self, text: str, k: int = 5, return_text: bool = False):
-        vec = np.asarray(embed_text(text, model=self.model), dtype="float32")
-        results = self.store.search(vec, k)
-        ids_scores = [(self.id_map.get(doc_id, str(doc_id)), score) for doc_id, score in results]
+        """Return top ``k`` results for a single query string."""
+        return self.query_multi([text], k=k, return_text=return_text)
+
+    def query_multi(
+        self,
+        texts: Iterable[str],
+        k: int = 5,
+        return_text: bool = False,
+        aggregate: bool = False,
+    ) -> List[Tuple[str, float] | Tuple[str, float, str]]:
+        """Return ranked results for multiple query strings.
+
+        Parameters
+        ----------
+        texts : Iterable[str]
+            Query strings to embed and search.
+        k : int, optional
+            Maximum number of results to return.
+        return_text : bool, optional
+            Include chunk text when available.
+        aggregate : bool, optional
+            Combine chunks belonging to the same document.
+        """
+
+        vectors = [np.asarray(embed_text(t, model=self.model), dtype="float32") for t in texts]
+
+        score_map: dict[str, List[float]] = {}
+        for vec in vectors:
+            for doc_id, score in self.store.search(vec, k):
+                name = self.id_map.get(doc_id, str(doc_id))
+                score_map.setdefault(name, []).append(score)
+
+        ranked_all: List[Tuple[str, float]] = sorted(
+            ((name, float(np.mean(scores))) for name, scores in score_map.items()),
+            key=lambda x: x[1],
+            reverse=True,
+        )
+
+        if aggregate:
+            doc_groups: dict[str, dict[str, List]] = {}
+            for name, score in ranked_all:
+                root = name.split("_chunk")[0]
+                entry = doc_groups.setdefault(root, {"scores": [], "chunks": []})
+                scores_list: List = entry["scores"]
+                chunks_list: List = entry["chunks"]
+                scores_list.append(score)
+                chunks_list.append(name)
+
+            aggregated: List[Tuple[str, float] | Tuple[str, float, str]] = []
+            for root, info in doc_groups.items():
+                avg_score = float(np.mean(info["scores"]))
+                if return_text and self.chunk_dir is not None:
+                    texts_combined = []
+                    for chunk_name in info["chunks"]:
+                        chunk_path = self.chunk_dir / f"{chunk_name}.txt"
+                        text_val = (
+                            chunk_path.read_text("utf-8") if chunk_path.exists() else ""
+                        )
+                        texts_combined.append(text_val)
+                    aggregated.append((root, avg_score, "\n".join(texts_combined)))
+                else:
+                    aggregated.append((root, avg_score))
+            return cast(
+                List[Tuple[str, float] | Tuple[str, float, str]],
+                sorted(aggregated, key=lambda x: x[1], reverse=True)[:k],
+            )
+
+        ranked = ranked_all[:k]
+
         if return_text and self.chunk_dir is not None:
-            enriched = []
-            for doc_id, score in ids_scores:
-                chunk_path = self.chunk_dir / f"{doc_id}.txt"
+            enriched: List[Tuple[str, float, str]] = []
+            for name, score in ranked:
+                chunk_path = self.chunk_dir / f"{name}.txt"
                 text_val = chunk_path.read_text("utf-8") if chunk_path.exists() else ""
-                enriched.append((doc_id, score, text_val))
-            return enriched
-        return ids_scores
+                enriched.append((name, score, text_val))
+            return cast(List[Tuple[str, float] | Tuple[str, float, str]], enriched)
+
+        return cast(List[Tuple[str, float] | Tuple[str, float, str]], ranked)

--- a/src/tests/test_retriever_multi.py
+++ b/src/tests/test_retriever_multi.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src'))
+
+from core.retrieval import retriever as retriever_mod
+
+
+class DummyStore:
+    def search(self, vec, k):
+        val = float(vec.flatten()[0])
+        if val == 0.0:
+            return [(10, 0.9), (20, 0.5)]
+        else:
+            return [(20, 0.8), (30, 0.4)]
+
+
+def test_query_multi_aggregate(tmp_path, monkeypatch):
+    r = retriever_mod.Retriever.__new__(retriever_mod.Retriever)
+    r.store = DummyStore()
+    r.model = 'dummy'
+    r.id_map = {10: 'docA_chunk00', 20: 'docA_chunk01', 30: 'docB_chunk00'}
+    r.chunk_dir = tmp_path
+
+    (tmp_path / 'docA_chunk00.txt').write_text('A00')
+    (tmp_path / 'docA_chunk01.txt').write_text('A01')
+    (tmp_path / 'docB_chunk00.txt').write_text('B00')
+
+    def fake_embed(text, model='dummy'):
+        return [0.0] if text == 'foo' else [1.0]
+
+    monkeypatch.setattr(retriever_mod, 'embed_text', fake_embed)
+
+    results = r.query_multi(['foo', 'bar'], k=2, return_text=True, aggregate=True)
+
+    assert results[0][0] == 'docA'
+    assert 'A00' in results[0][2] and 'A01' in results[0][2]
+    assert results[1][0] == 'docB'


### PR DESCRIPTION
## Summary
- support multi-query search and aggregation in `Retriever`
- expose `Retriever` from retrieval package
- document new intent and inputs in `.purpose.md`
- add regression test for `query_multi`
- log design note for retriever update

## Testing
- `ruff check src/core/retrieval/retriever.py src/core/retrieval/__init__.py src/tests/test_retriever_multi.py`
- `mypy --ignore-missing-imports src/core/retrieval/retriever.py src/core/retrieval/__init__.py src/tests/test_retriever_multi.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e70053b1483239ff1000fd0547d22