### PR TITLE
Add export parse subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ python main.py organize-all --cluster-file output/cluster_assignments.json
 # Semantic search over your corpus
 python main.py search semantic "How did Lincoln justify suspension of habeas corpus?" --k 5
 
+# Parse a ChatGPT export
+python main.py export parse export.zip
+
 # Run a cooperative agent workflow
 python main.py agent run "Summarize recent policy shifts" --roles synthesizer,associative
 ```

--- a/intents/2025-07-09__cli_export_app.intent.md
+++ b/intents/2025-07-09__cli_export_app.intent.md
@@ -1,0 +1,1 @@
+Added Typer sub-app `export` with a `parse` command to handle ChatGPT data exports. Updated main CLI and docs.

--- a/purpose_files/cli_combined.purpose.md
+++ b/purpose_files/cli_combined.purpose.md
@@ -18,6 +18,7 @@
 | 📤 Out    | organized_dir | Folder  | Output directory of categorized files and metadata     |
 | 📤 Out    | embeddings    | JSON    | Document embedding vectors                             |
 | 📤 Out    | s3_uploads    | S3      | Raw and parsed documents uploaded                      |
+| 📤 Out    | chatgpt_texts | Folder  | Conversation transcripts from ChatGPT exports |
 
 ### 🔗 Dependencies
 - `core.workflows.main_commands` – Orchestrates classification, upload, ingestion
@@ -41,6 +42,7 @@
 - `agent` orchestrates cooperative roles such as Synthesizer and Insight Aggregator while respecting a budget cap.
 - Classification commands now accept `--segmentation` to switch between semantic or paragraph chunking.
 
+- Export command `export parse` converts ChatGPT exports to text files.
 ### 9 Pipeline Integration
 - @ai-pipeline-order: inverse
 - **Coordination Mechanics:** CLI commands orchestrate uploads, segmentation, embedding, and retrieval through underlying workflow modules.

--- a/src/cli/export.py
+++ b/src/cli/export.py
@@ -1,0 +1,15 @@
+import typer
+from pathlib import Path
+
+from core.config.config_registry import get_path_config
+from core.parsing import parse_chatgpt_export
+
+app = typer.Typer()
+
+@app.command()
+def parse(export_zip: Path, out_dir: Path = None):
+    """Parse a ChatGPT export ZIP into conversation text files."""
+    paths = get_path_config()
+    out = out_dir or paths.parsed / "chatgpt_export"
+    parse_chatgpt_export(export_zip, out)
+

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -8,6 +8,7 @@ import cli.pipeline as pipeline
 import cli.tokens as tokens
 import cli.search as search
 import cli.agent as agent
+import cli.export as export
 
 app = typer.Typer()
 
@@ -19,6 +20,7 @@ app.add_typer(pipeline.app, name="pipeline")
 app.add_typer(tokens.app, name="tokens")
 app.add_typer(search.app, name="search")
 app.add_typer(agent.app, name="agent")
+app.add_typer(export.app, name="export")
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
## Summary
- add `cli.export` with a `parse` command for ChatGPT exports
- wire new sub-app into main CLI
- document the command in README
- record intent
- update CLI purpose file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tiktoken')*

------
https://chatgpt.com/codex/tasks/task_e_686ea9ca61888323993f819c80b93442