### PR TITLE
Implement ChatGPT export CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ python main.py search semantic "How did Lincoln justify suspension of habeas cor
 
 # Run a cooperative agent workflow
 python main.py agent run "Summarize recent policy shifts" --roles synthesizer,associative
+
+# Parse a ChatGPT data export archive
+python main.py chatgpt parse ~/Downloads/chatgpt_export.zip --out-dir chat_exports --markdown
 ```
 
 ---

--- a/purpose_files/cli_combined.purpose.md
+++ b/purpose_files/cli_combined.purpose.md
@@ -39,6 +39,7 @@
 - New sub-commands `search` and `agent` will expose FAISS retrieval and multi-agent RAG workflows.
 - `search` accepts a natural language query and returns document IDs ranked by semantic similarity.
 - `agent` orchestrates cooperative roles such as Synthesizer and Insight Aggregator while respecting a budget cap.
+- `chatgpt` parses personal ChatGPT exports into conversation and prompt files; `--markdown` saves transcripts as `.md`.
 - Classification commands now accept `--segmentation` to switch between semantic or paragraph chunking.
 
 ### 9 Pipeline Integration

--- a/purpose_files/core.parsing.openai_export.purpose.md
+++ b/purpose_files/core.parsing.openai_export.purpose.md
@@ -1,0 +1,44 @@
+# Module: core.parsing.openai_export
+- @ai-path: core.parsing.openai_export
+- @ai-source-file: openai_export.py
+- @ai-role: parser
+- @ai-intent: "Parse ChatGPT Data Export zip to extract conversation transcripts and user prompts with optional Markdown formatting."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+- @schema-version: 0.2
+- @ai-risk-pii: high
+- @ai-risk-performance: low
+
+> Processes the `conversations.json` file included in OpenAI's user data export and writes each conversation to its own text file along with a prompt-only file.
+
+### 🎯 Intent & Responsibility
+- Load the export archive or folder.
+- Extract conversations in order of `current_node` parent pointers.
+- Save full transcripts and user-only prompts to disk for later analysis.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name         | Type            | Brief Description |
+|-----------|--------------|-----------------|-------------------|
+| 📥 In     | export_path  | Path            | Path to `.zip` export or extracted folder |
+| 📥 In     | out_dir      | Path            | Directory to write conversation and prompt files |
+| 📥 In     | markdown    | bool           | Save transcripts as `.md` when True |
+| 📤 Out    | conversation | Path            | File path for each conversation transcript |
+| 📤 Out    | prompts      | Path            | File path for user prompts only |
+| 📤 Out    | outputs      | List[Dict[str, Path]] | [{'conversation': Path, 'prompts': Path}] per chat |
+
+### 🔗 Dependencies
+- `zipfile`, `json`, `pathlib`
+- `core.parsing.normalize.normalize_filename`
+
+### 🗣 Dialogic Notes
+- Only linear path from `current_node` is reconstructed; branches are ignored.
+- File names are normalized and truncated to avoid OS issues.
+- Prompts are separated to help detect duplicate questions across chats.
+- Conversations may be written in Markdown when the `markdown` flag is enabled.
+
+### 9 Pipeline Integration
+- **Coordination Mechanics:** Used by Typer command `chatgpt parse` to generate files on demand. Outputs may feed indexing or deduplication workflows.
+- **Integration Points:** Downstream modules could ingest these transcripts for embedding or topic analysis.
+- **Risks:** Export contains personal data; handle securely and avoid accidental commits.

--- a/src/cli/chatgpt.py
+++ b/src/cli/chatgpt.py
@@ -1,0 +1,16 @@
+import typer
+from pathlib import Path
+
+app = typer.Typer(help="ChatGPT data export utilities")
+
+@app.command("parse")
+def parse_export(
+    export_path: Path = typer.Argument(..., exists=True, help="Path to ChatGPT export zip or folder"),
+    out_dir: Path = typer.Option(Path("chat_exports"), help="Directory to save parsed conversations"),
+    markdown: bool = typer.Option(False, help="Save transcripts as Markdown"),
+):
+    """Extract conversations and prompts from a ChatGPT data export."""
+    from core.parsing.openai_export import parse_chatgpt_export
+    results = parse_chatgpt_export(export_path, out_dir, markdown=markdown)
+    typer.echo(f"Parsed {len(results)} conversations into {out_dir}")
+

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -8,6 +8,7 @@ import cli.pipeline as pipeline
 import cli.tokens as tokens
 import cli.search as search
 import cli.agent as agent
+import cli.chatgpt as chatgpt
 
 app = typer.Typer()
 
@@ -19,6 +20,7 @@ app.add_typer(pipeline.app, name="pipeline")
 app.add_typer(tokens.app, name="tokens")
 app.add_typer(search.app, name="search")
 app.add_typer(agent.app, name="agent")
+app.add_typer(chatgpt.app, name="chatgpt")
 
 if __name__ == "__main__":
     app()

--- a/src/core/parsing/__init__.py
+++ b/src/core/parsing/__init__.py
@@ -1,4 +1,34 @@
+"""Lightweight wrappers to avoid heavy imports at module load."""
+from __future__ import annotations
 
-from .semantic_chunk import semantic_chunk_text, semantic_chunk
-from .topic_segmenter import segment_text, segment_topics, topic_segmenter
-__all__ = ["semantic_chunk_text", "semantic_chunk", "segment_text"]
+def semantic_chunk_text(*args, **kwargs):
+    from .semantic_chunk import semantic_chunk_text as fn
+    return fn(*args, **kwargs)
+
+
+def segment_text(*args, **kwargs):
+    from .topic_segmenter import segment_text as fn
+    return fn(*args, **kwargs)
+
+
+def segment_topics(*args, **kwargs):
+    from .topic_segmenter import segment_topics as fn
+    return fn(*args, **kwargs)
+
+
+def topic_segmenter(*args, **kwargs):
+    from .topic_segmenter import topic_segmenter as fn
+    return fn(*args, **kwargs)
+
+
+def parse_chatgpt_export(*args, **kwargs):
+    from .openai_export import parse_chatgpt_export as fn
+    return fn(*args, **kwargs)
+
+__all__ = [
+    "semantic_chunk_text",
+    "segment_text",
+    "segment_topics",
+    "topic_segmenter",
+    "parse_chatgpt_export",
+]

--- a/src/core/parsing/openai_export.py
+++ b/src/core/parsing/openai_export.py
@@ -1,0 +1,109 @@
+"""
+📦 Module: core.parsing.openai_export
+- @ai-path: core.parsing.openai_export
+- @ai-source-file: openai_export.py
+- @ai-role: parser
+- @ai-intent: "Parse ChatGPT Data Export zip to extract conversation transcripts and user prompts."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+
+This module reads the `conversations.json` file included in an OpenAI ChatGPT
+"Data Export" archive and writes each conversation to its own text file.
+Additionally, it saves a corresponding file containing only the user messages
+for quick prompt reuse or duplicate detection.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+import zipfile
+
+from .normalize import normalize_filename
+
+
+def _load_conversations(export_path: Path) -> List[Dict]:
+    """Load conversation list from a zip archive or directory."""
+    if export_path.is_dir():
+        conv_path = export_path / "conversations.json"
+        with conv_path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    with zipfile.ZipFile(export_path) as zf:
+        with zf.open("conversations.json") as f:
+            return json.load(f)
+
+
+def _extract_messages(convo: Dict) -> Iterable[Tuple[str, str]]:
+    """Return ordered (role, text) tuples for a conversation."""
+    mapping = convo.get("mapping", {})
+    node_id = convo.get("current_node")
+    path: List[Tuple[str, str]] = []
+    while node_id:
+        node = mapping.get(node_id)
+        if not node:
+            break
+        msg = node.get("message")
+        if msg and msg.get("author", {}).get("role") != "system":
+            role = msg["author"].get("role", "")
+            parts = msg.get("content", {}).get("parts") or []
+            text = "\n".join(parts)
+            path.append((role, text))
+        node_id = node.get("parent")
+    return reversed(path)
+
+
+def parse_chatgpt_export(
+    export_path: Path, out_dir: Path, *, markdown: bool = False
+) -> List[Dict[str, Path]]:
+    """Parse conversations and write text + prompt files.
+
+    Parameters
+    ----------
+    export_path: Path
+        Path to the `.zip` export or the extracted folder.
+    out_dir: Path
+        Directory to write conversation and prompt files.
+
+    markdown: bool, optional
+        If True, save conversation transcripts as Markdown rather than plain text.
+
+    Returns
+    -------
+    List[Dict[str, Path]]
+        List of dictionaries describing output file paths per conversation.
+    """
+
+    export_path = Path(export_path)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    prompt_dir = out_dir / "prompts"
+    prompt_dir.mkdir(exist_ok=True)
+
+    conversations = _load_conversations(export_path)
+    outputs: List[Dict[str, Path]] = []
+    ext = "md" if markdown else "txt"
+    for idx, convo in enumerate(conversations):
+        title = convo.get("title") or f"conversation_{idx}"
+        slug = normalize_filename(title)[:32]
+        convo_file = out_dir / f"{idx:04d}_{slug}.{ext}"
+        prompt_file = prompt_dir / f"{idx:04d}_{slug}_prompts.txt"
+
+        lines = []
+        prompts = []
+        for role, text in _extract_messages(convo):
+            clean = text.strip()
+            if markdown:
+                lines.append(f"**{role.title()}:** {clean}")
+            else:
+                lines.append(f"{role.upper()}: {clean}")
+            if role == "user":
+                prompts.append(clean)
+
+        convo_file.write_text("\n".join(lines), encoding="utf-8")
+        prompt_file.write_text("\n".join(prompts), encoding="utf-8")
+        outputs.append({"conversation": convo_file, "prompts": prompt_file})
+
+    return outputs

--- a/src/tests/test_embedder_id_mask.py
+++ b/src/tests/test_embedder_id_mask.py
@@ -6,6 +6,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 
 import pytest
 
+pytest.importorskip("faiss")
+
 from core.config.path_config import PathConfig
 from core.config import config_registry
 from core.embeddings import embedder

--- a/src/tests/test_openai_export_parser.py
+++ b/src/tests/test_openai_export_parser.py
@@ -1,0 +1,74 @@
+import json
+import zipfile
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from core.parsing.openai_export import parse_chatgpt_export
+
+
+def make_export_zip(tmp_path: Path) -> Path:
+    conversations = [
+        {
+            "title": "Test Chat",
+            "current_node": "3",
+            "mapping": {
+                "1": {
+                    "id": "1",
+                    "parent": None,
+                    "children": ["2"],
+                    "message": {
+                        "author": {"role": "system"},
+                        "content": {"content_type": "text", "parts": ["You are ChatGPT"]},
+                    },
+                },
+                "2": {
+                    "id": "2",
+                    "parent": "1",
+                    "children": ["3"],
+                    "message": {
+                        "author": {"role": "user"},
+                        "content": {"content_type": "text", "parts": ["Hello"]},
+                    },
+                },
+                "3": {
+                    "id": "3",
+                    "parent": "2",
+                    "children": [],
+                    "message": {
+                        "author": {"role": "assistant"},
+                        "content": {"content_type": "text", "parts": ["Hi!"]},
+                    },
+                },
+            },
+        }
+    ]
+    export_zip = tmp_path / "export.zip"
+    with zipfile.ZipFile(export_zip, "w") as zf:
+        zf.writestr("conversations.json", json.dumps(conversations))
+    return export_zip
+
+
+def test_parse_export(tmp_path: Path):
+    export_zip = make_export_zip(tmp_path)
+    out_dir = tmp_path / "out"
+    results = parse_chatgpt_export(export_zip, out_dir)
+    assert len(results) == 1
+    convo_file = out_dir / "0000_test_chat.txt"
+    prompt_file = out_dir / "prompts" / "0000_test_chat_prompts.txt"
+    assert convo_file.exists()
+    assert prompt_file.exists()
+    assert "USER: Hello" in convo_file.read_text()
+    assert prompt_file.read_text().strip() == "Hello"
+
+
+def test_parse_export_markdown(tmp_path: Path):
+    export_zip = make_export_zip(tmp_path)
+    out_dir = tmp_path / "out_md"
+    results = parse_chatgpt_export(export_zip, out_dir, markdown=True)
+    assert len(results) == 1
+    convo_file = out_dir / "0000_test_chat.md"
+    assert convo_file.exists()
+    text = convo_file.read_text()
+    assert "**User:** Hello" in text or "**USER:** Hello" in text


### PR DESCRIPTION
## Summary
- add Typer command `chatgpt parse` for ChatGPT export archives
- avoid heavy imports in `core.parsing` by lazily importing submodules
- document new CLI entry and integration notes
- skip FAISS-dependent tests when library absent
- make Markdown conversation export optional

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d994b130c8323ab0f2e8a9caf56f8