### PR TITLE
Handle nested ChatGPT exports

### DIFF
--- a/purpose_files/core.parsing.openai_export.purpose.md
+++ b/purpose_files/core.parsing.openai_export.purpose.md
@@ -38,6 +38,8 @@
 - File names are normalized and truncated to avoid OS issues.
 - Prompts are separated to help detect duplicate questions across chats.
 - Conversations may be written in Markdown when the `markdown` flag is enabled.
+- Zip archives with a top-level directory are supported by scanning for
+  `conversations.json` within the archive.
 
 ### 9 Pipeline Integration
 - **Coordination Mechanics:** Used by Typer command `chatgpt parse` to generate files on demand. Outputs may feed indexing or deduplication workflows.

--- a/src/tests/test_openai_export_parser.py
+++ b/src/tests/test_openai_export_parser.py
@@ -50,6 +50,17 @@ def make_export_zip(tmp_path: Path) -> Path:
     return export_zip
 
 
+def make_nested_export_zip(tmp_path: Path) -> Path:
+    """Create a zip where conversations.json is under a folder."""
+    conversations = [{"title": "Nested", "current_node": None, "mapping": {}}]
+    export_zip = tmp_path / "nested.zip"
+    with zipfile.ZipFile(export_zip, "w") as zf:
+        zf.writestr(
+            "ChatGPT Export/conversations.json", json.dumps(conversations)
+        )
+    return export_zip
+
+
 def test_parse_export(tmp_path: Path):
     export_zip = make_export_zip(tmp_path)
     out_dir = tmp_path / "out"
@@ -71,3 +82,12 @@ def test_parse_export_markdown(tmp_path: Path):
     assert convo_file.exists()
     text = convo_file.read_text()
     assert "**User:** Hello" in text or "**USER:** Hello" in text
+
+
+def test_parse_export_nested_dir(tmp_path: Path):
+    export_zip = make_nested_export_zip(tmp_path)
+    out_dir = tmp_path / "out_nested"
+    results = parse_chatgpt_export(export_zip, out_dir)
+    assert len(results) == 1
+    convo_file = out_dir / "0000_nested.txt"
+    assert convo_file.exists()


### PR DESCRIPTION
## Summary
- support exports where `conversations.json` lives under a folder
- cover nested archive layout in tests
- note nested-directory support in parser purpose file

## Testing
- `pip install tiktoken --quiet`
- `pip install faiss-cpu --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872930e35a483238992cd60617cf5fa