### PR TITLE
Support file-based vector search

### DIFF
--- a/purpose_files/cli_combined.purpose.md
+++ b/purpose_files/cli_combined.purpose.md
@@ -39,6 +39,7 @@
 - Long-term direction may involve breaking commands into namespace groupings or supporting `--dry-run` and audit modes.
 - New sub-commands `search` and `agent` will expose FAISS retrieval and multi-agent RAG workflows.
 - `search` accepts a natural language query and returns document IDs ranked by semantic similarity.
+- `search file` looks up documents similar to the contents of a local text file.
 - `agent` orchestrates cooperative roles such as Synthesizer and Insight Aggregator while respecting a budget cap.
 - `chatgpt` parses personal ChatGPT exports into conversation and prompt files; `--markdown` saves transcripts as `.md`.
 - A `dedup` command consolidates prompt text files into a single deduplicated list.

--- a/purpose_files/core.retrieval.retriever.purpose.md
+++ b/purpose_files/core.retrieval.retriever.purpose.md
@@ -24,6 +24,7 @@
 |-----------|------|------|-------------------|
 | 📥 In | text | str | Search query text (via ``query``) |
 | 📥 In | texts | Iterable[str] | Multiple search queries (``query_multi``) |
+| 📥 In | file | Path | Text file used as query (``query_file``) |
 | 📥 In | k | int | Number of results to return |
 | 📥 In | chunk_dir | Path (optional) | Directory holding text chunks for retrieval |
 | 📥 In | return_text | bool (optional) | Include chunk text when `chunk_dir` is configured |
@@ -43,6 +44,7 @@
 - Uses `id_map.json` to translate FAISS integer IDs back to document filenames.
 - When embeddings include chunk IDs (`doc_chunk01`), results may refer to those composite identifiers and `return_text` can load the chunk file if available.
 - `query_multi` merges scores across queries and can group chunks by their document prefix when `aggregate=True`.
+- `query_file` reads text from disk then delegates to `query`.
 
 ### 9 Pipeline Integration
 - @ai-pipeline-order: inverse

--- a/src/cli/search.py
+++ b/src/cli/search.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import typer
 
 from core.retrieval.retriever import Retriever
@@ -13,5 +14,15 @@ def semantic(query: str, k: int = 5):
     retriever = Retriever()
     logger.info("Running semantic search for: %s", query)
     hits = retriever.query(query, k=k)
+    for doc_id, score in hits:
+        print(doc_id, f"{score:.3f}")
+
+
+@app.command("file")
+def semantic_file(file_path: typer.FileText, k: int = 5):
+    """Return top-k IDs similar to the text contained in ``file_path``."""
+    retriever = Retriever()
+    logger.info("Running semantic search for file: %s", file_path.name)
+    hits = retriever.query_file(Path(file_path.name), k=k)
     for doc_id, score in hits:
         print(doc_id, f"{score:.3f}")

--- a/src/core/retrieval/retriever.py
+++ b/src/core/retrieval/retriever.py
@@ -48,6 +48,11 @@ class Retriever:
         """Return top ``k`` results for a single query string."""
         return self.query_multi([text], k=k, return_text=return_text)
 
+    def query_file(self, file: str | Path, k: int = 5, return_text: bool = False):
+        """Return top ``k`` results using the contents of ``file`` as the query."""
+        text = Path(file).read_text("utf-8")
+        return self.query(text, k=k, return_text=return_text)
+
     def query_multi(
         self,
         texts: Iterable[str],

--- a/src/tests/test_retriever_file.py
+++ b/src/tests/test_retriever_file.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src'))
+
+from core.retrieval import retriever as retriever_mod
+
+class DummyStore:
+    def search(self, vec, k):
+        return [(10, 0.9)]
+
+def test_query_file(tmp_path, monkeypatch):
+    file_path = tmp_path / 'sample.txt'
+    file_path.write_text('hello')
+
+    r = retriever_mod.Retriever.__new__(retriever_mod.Retriever)
+    r.store = DummyStore()
+    r.model = 'dummy'
+    r.id_map = {10: 'docA'}
+    r.chunk_dir = None
+
+    monkeypatch.setattr(retriever_mod, 'embed_text', lambda text, model='dummy': [0.0])
+
+    results = r.query_file(file_path, k=1)
+    assert results == [('docA', 0.9)]


### PR DESCRIPTION
## Summary
- add `query_file` method to `Retriever`
- expose `search file` CLI subcommand
- document new command and method
- test file-based search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872c65bb2e083238107d84c8e23fb2e