### PR TITLE
Fix openai export parser when messages missing

### DIFF
--- a/intents/2025-07-12__openai_export_fix.intent.md
+++ b/intents/2025-07-12__openai_export_fix.intent.md
@@ -1,0 +1,2 @@
+Added validation for _extract_messages returning None in parse_chatgpt_export.
+Now raises ValueError if no messages can be parsed from a conversation.

--- a/purpose_files/core.parsing.openai_export.purpose.md
+++ b/purpose_files/core.parsing.openai_export.purpose.md
@@ -3,7 +3,7 @@
 - @ai-source-file: openai_export.py
 - @ai-role: parser
 - @ai-intent: "Parse ChatGPT Data Export zip to extract conversation transcripts and user prompts with optional Markdown formatting."
-- @ai-version: 0.1.0
+- @ai-version: 0.1.1
 - @ai-generated: true
 - @ai-verified: false
 - @human-reviewed: false
@@ -27,6 +27,7 @@
 | 📤 Out    | conversation | Path            | File path for each conversation transcript |
 | 📤 Out    | prompts      | Path            | File path for user prompts only |
 | 📤 Out    | outputs      | List[Dict[str, Path]] | [{'conversation': Path, 'prompts': Path}] per chat |
+| ❗ Error   | ValueError   | N/A             | Raised when messages cannot be extracted |
 =======
 
 ### 🔗 Dependencies

--- a/src/core/parsing/openai_export.py
+++ b/src/core/parsing/openai_export.py
@@ -103,7 +103,10 @@ def parse_chatgpt_export(
         prompt_file = prompt_dir / f"{idx:04d}_{slug}_prompts.txt"
         lines = []
         prompts = []
-        for role, text in _extract_messages(convo):
+        msgs = _extract_messages(convo)
+        if msgs is None:
+            raise ValueError("Failed to extract messages from conversation")
+        for role, text in msgs:
             clean = text.strip()
             if markdown:
                 lines.append(f"**{role.title()}:** {clean}")


### PR DESCRIPTION
## Summary
- validate `_extract_messages` return value before iterating
- document ValueError in `.purpose.md`
- test parser when `_extract_messages` returns None

## Testing
- `ruff check src/core/parsing/openai_export.py src/tests/test_openai_export_parser.py`
- `mypy --ignore-missing-imports src/core/parsing/openai_export.py src/tests/test_openai_export_parser.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872c75afb988323ac6a15c248ae2458