### PR TITLE
Fix chat export filename sanitization

### DIFF
--- a/purpose_files/core.parsing.normalize.purpose.md
+++ b/purpose_files/core.parsing.normalize.purpose.md
@@ -1,0 +1,39 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+
+# Module: core.parsing.normalize
+- @ai-path: core.parsing.normalize
+- @ai-source-file: normalize.py
+- @ai-role: utility
+- @ai-intent: "Standardize strings for safe filenames."
+- @schema-version: 0.2
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+
+> Provides a lightweight helper for converting arbitrary labels into filesystem-safe slugs.
+
+### 🎯 Intent & Responsibility
+- Replace spaces and invalid characters with underscores.
+- Lowercase results and collapse repeated underscores.
+- Used across parsing modules to ensure consistent file names.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | name | str | Raw title or identifier |
+| 📤 Out | slug | str | Normalized path-safe name |
+
+### 🔗 Dependencies
+- `re`
+- Consumed by `core.parsing.openai_export` and potential upload utilities.
+
+### 9 Pipeline Integration
+- **Coordination Mechanics:** Called inline by parsers when generating output file paths.
+- **Integration Points:** Downstream modules expect sanitized names for metadata files and transcripts.
+- **Risks:** Overzealous filtering could produce duplicate slugs; uniqueness is not guaranteed.

--- a/src/core/parsing/normalize.py
+++ b/src/core/parsing/normalize.py
@@ -1,44 +1,19 @@
 """
-📦 Module: core_lib.utils.strings
-- @ai-path: core_lib.utils.strings
-- @ai-source-file: combined_utils.py
-- @ai-role: String Utilities
-- @ai-intent: "Standardize filenames and identifiers to lowercase with underscores for safe use across the system."
-
-🔍 Module Summary:
-This module provides lightweight string normalization utilities to ensure safe, standardized filenames 
-and identifiers across cloud and local systems. It primarily transforms names to lowercase and replaces 
-spaces or hyphens with underscores.
-
-🗂️ Contents:
-
-| Name               | Type     | Purpose                                  |
-|:-------------------|:---------|:-----------------------------------------|
-| normalize_filename | Function | Convert names to lowercase and underscore-separated format. |
-
-🧠 For AI Agents:
-- @ai-dependencies: None
-- @ai-uses: str.lower(), str.replace()
-- @ai-tags: normalization, string-utils, identifier-cleanup
-
-⚙️ Meta:
-- @ai-version: 0.1.0
-- @ai-generated: true
-- @ai-verified: false
-
-📝 Human Collaboration:
-- @human-reviewed: false
-- @human-edited: false
-- @last-commit: Add basic string cleaner for identifiers
-- @change-summary: Normalize filenames and labels for safe downstream use
-- @notes: ""
-
-👤 Human Overview:
-    - Context: Ensures consistent naming across document upload, storage, and retrieval pipelines.
-    - Change Caution: Original case and formatting are lost; irreversible unless tracked separately.
-    - Future Hints: Extend normalization options to support slug generation for web compatibility.
+📦 Module: core.parsing.normalize
+- @ai-path: core.parsing.normalize
+- @ai-source-file: normalize.py
+- @ai-role: utility
+- @ai-intent: "Standardize strings for safe filenames"
+- @schema-version: 0.2
 """
+
+import re
 
 
 def normalize_filename(name: str) -> str:
-    return name.replace(" ", "_").replace("-", "_").lower()
+    """Return a lowercase, path-safe slug."""
+    sanitized = re.sub(r"[\\/:*?\"<>|]", "_", name)
+    sanitized = sanitized.replace(" ", "_").replace("-", "_")
+    sanitized = re.sub(r"[^\w]+", "_", sanitized)
+    sanitized = re.sub(r"_+", "_", sanitized).strip("_")
+    return sanitized.lower()


### PR DESCRIPTION
## Summary
- sanitize invalid path characters in `normalize_filename`
- cover edge case for titles with slashes
- document new `core.parsing.normalize` module purpose

## Testing
- `ruff check --fix src/core/parsing/normalize.py src/tests/test_openai_export_parser.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687476e5c1e883238fa28fb7b36a8be8