### PR TITLE
Fix embedding file selection in CLI

### DIFF
--- a/purpose_files/cli.embed.purpose.md
+++ b/purpose_files/cli.embed.purpose.md
@@ -1,0 +1,35 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+
+# Module: cli.embed
+# @ai-path: cli.embed
+# @ai-source-file: embed.py
+# @ai-role: CLI Entrypoint
+# @ai-intent: "Invoke document embedding generation via Typer command."
+
+> Thin command wrapper that calls `core.embeddings.embedder.generate_embeddings`.
+
+### 🎯 Intent & Responsibility
+- Provide `embed all` for embedding parsed or summarized text files.
+- Relay the `segment_mode` configuration from `PathConfig`.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name   | Type | Brief Description |
+|-----------|-------|------|-------------------|
+| 📥 In     | method | str  | Source text: parsed, summary, raw, meta |
+| 📥 In     | out_path | Path | Optional path for embeddings JSON |
+| 📤 Out    | rich_doc_embeddings.json | File | Vectors persisted by embedder |
+
+### 🔗 Dependencies
+- `typer`
+- `core.embeddings.embedder.generate_embeddings`
+- `core.config.config_registry.get_path_config`
+
+### 🗣 Dialogic Notes
+- Registered under `embed` sub-command in `cli.main`.
+- Default method set to `parsed` to embed text files directly.

--- a/src/cli/embed.py
+++ b/src/cli/embed.py
@@ -10,7 +10,7 @@ app = typer.Typer()
 
 @app.command()
 def all(
-    method: str = typer.Option("summary", help="Which text source to embed: parsed, summary, raw, meta"),
+    method: str = typer.Option("parsed", help="Which text source to embed: parsed, summary, raw, meta"),
     out_path: Path = typer.Option(None, help="Output path for embeddings JSON file")
 ):
     """

--- a/src/core/embeddings/embedder.py
+++ b/src/core/embeddings/embedder.py
@@ -96,7 +96,8 @@ def generate_embeddings(
 
     chunk_dir = chunk_dir or (paths.vector / "chunks")
 
-    for file in sorted(source_dir.glob("*.txt" if method != "meta" else "*.meta.json")):
+    pattern = "*.meta.json" if method in {"summary", "meta"} else "*.txt"
+    for file in sorted(source_dir.glob(pattern)):
         doc_id = file.stem
 
         if method == "parsed":


### PR DESCRIPTION
## Summary
- set `cli.embed` default method to `parsed`
- respect summary/meta modes when globbing files
- document `cli.embed` entrypoint purpose

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68751dd2c6e88323be39afe4a5c644a9