### PR TITLE
Fix ast dependency extractor Unicode handling

### DIFF
--- a/purpose_files/tools.ast_dependency_extractor.purpose.md
+++ b/purpose_files/tools.ast_dependency_extractor.purpose.md
@@ -1,0 +1,32 @@
+# Module: tools.ast_dependency_extractor
+# @ai-path: tools.ast_dependency_extractor
+# @ai-source-file: ast_dependency_extractor.py
+# @ai-role: cli_tool
+# @ai-intent: "Trace function and method calls across a package using AST parsing."
+# @ai-version: 0.1.0
+# @ai-generated: true
+# @ai-verified: false
+# @human-reviewed: false
+# @schema-version: 0.2
+
+### 🎯 Intent & Responsibility
+- Parse Python files to map which functions invoke which others.
+- Provide a Typer CLI (`analyze`) to export edges or an adjacency matrix.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name        | Type | Brief Description |
+|-----------|------------|------|------------------|
+| 📥 In     | source_dir  | str  | Root folder for `.py` files |
+| 📥 In     | recursive   | bool | Traverse subdirectories |
+| 📥 In     | ignore_dirs | str  | Comma-separated directories to skip |
+| 📥 In     | output      | Path | Optional CSV export path |
+| 📥 In     | matrix      | bool | Output adjacency matrix if true |
+| 📥 In     | config      | Path | `.graphconfig.json` override |
+| 📤 Out    | csv         | File | Dependency edges or matrix |
+
+### 🔗 Dependencies
+- `ast`, `os`, `tokenize`, `pandas`, `networkx`, `typer`
+
+### 🗣 Dialogic Notes
+- Edges can feed into `method_graph` for visualization.
+- Useful for QAT modules analyzing package structure.

--- a/src/tools/ast_dependency_extractor.py
+++ b/src/tools/ast_dependency_extractor.py
@@ -51,6 +51,7 @@ import os
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Tuple
+import tokenize
 
 import networkx as nx
 import pandas as pd
@@ -68,12 +69,17 @@ class ASTDependencyExtractor:
     def process_file(self, filepath: str, module_name: str):
         self.current_module = module_name
         self.imports = {}  # reset for each file
-        with open(filepath, "r", encoding="utf-8") as f:
-            try:
-                tree = ast.parse(f.read(), filename=filepath)
-                self._walk_tree(tree)
-            except SyntaxError:
-                typer.echo(f"⚠️  Skipping {filepath} due to syntax error.")
+        try:
+            with tokenize.open(filepath) as f:
+                source = f.read()
+        except (SyntaxError, UnicodeDecodeError, LookupError) as exc:
+            typer.echo(f"⚠️  Skipping {filepath} due to decode error: {exc}")
+            return
+        try:
+            tree = ast.parse(source, filename=filepath)
+            self._walk_tree(tree)
+        except SyntaxError:
+            typer.echo(f"⚠️  Skipping {filepath} due to syntax error.")
 
     def _walk_tree(self, tree: ast.AST):
         class ImportResolver(ast.NodeVisitor):


### PR DESCRIPTION
## Summary
- handle unicode decode failures in `ast_dependency_extractor`
- synchronize combined script
- document tool purpose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a85d6b0888323a791e766a5198954