### PR TITLE
Add simple Streamlit chat GUI

### DIFF
--- a/purpose_files/gui.chat_gui.purpose.md
+++ b/purpose_files/gui.chat_gui.purpose.md
@@ -1,0 +1,49 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+
+- @ai-path: gui.chat_gui
+- @ai-source-file: gui/chat_gui.py
+- @ai-role: conversation_ui
+- @ai-intent: "Provide a Streamlit-based interface for chatting with the configured OpenAI model."
+- @schema-version: 0.2
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+
+# Module: gui.chat_gui
+> Minimal chat interface to converse with the OpenAI model defined in `RemoteConfig`.
+
+### 🎯 Intent & Responsibility
+- Render a Streamlit UI for user and assistant messages.
+- Maintain conversation state in `st.session_state`.
+- Send conversation to OpenAI via `run_openai_chat`, enforcing `BudgetTracker` limits.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | messages | List[Dict[str, str]] | Conversation history with `role` and `content` fields. |
+| 📥 In | model | str | Model ID to use (default `gpt-4o`). |
+| 📥 In | config | RemoteConfig | Provides API key for OpenAI access. |
+| 📤 Out | updated_messages | List[Dict[str, str]] | Chat history appended with assistant reply. |
+
+### 🔗 Dependencies
+- `streamlit`
+- `openai`, `tiktoken`
+- `core.config.remote_config.RemoteConfig`
+- `core.utils.budget_tracker.get_budget_tracker`
+
+### 🗣 Dialogic Notes
+- Launch with `streamlit run chat_gui.py`.
+- Requires `core/config/remote_config.json` containing `openai_api_key`.
+- Designed for quick experiments; no retrieval or memory injection yet.
+
+### 9 Pipeline Integration
+- **Coordination Mechanics:** Standalone interface; loops via Streamlit callbacks.
+- **Integration Points:** Could later integrate with `Retriever` or `FrameStore` for RAG workflows.
+- **Risks:** Missing config or network failures will raise runtime errors; no retry logic implemented.

--- a/src/gui/chat_gui.py
+++ b/src/gui/chat_gui.py
@@ -1,0 +1,68 @@
+"""Streamlit-based chat interface for OpenAI models."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import streamlit as st  # type: ignore
+import tiktoken
+from openai import OpenAI
+
+from core.config.remote_config import RemoteConfig  # type: ignore
+from core.llm.invoke import LLM_COMPLETION_COST_PER_1K, LLM_PROMPT_COST_PER_1K  # type: ignore
+from core.utils.budget_tracker import get_budget_tracker  # type: ignore
+
+
+def run_openai_chat(
+    messages: List[Dict[str, str]],
+    model: str = "gpt-4o",
+    temperature: float = 0.5,
+    max_tokens: int = 300,
+    api_key: str | None = None,
+) -> str:
+    """Send conversation history to OpenAI and return the assistant reply."""
+    client = OpenAI(api_key=api_key or RemoteConfig.from_file().openai_api_key)
+    tracker = get_budget_tracker()
+    if tracker:
+        enc = tiktoken.encoding_for_model(model)
+        joined = "".join(m["content"] for m in messages)
+        prompt_tokens = len(enc.encode(joined, disallowed_special=()))
+        est_cost = (
+            prompt_tokens / 1000 * LLM_PROMPT_COST_PER_1K.get(model, 0)
+            + max_tokens / 1000 * LLM_COMPLETION_COST_PER_1K.get(model, 0)
+        )
+        if not tracker.check(est_cost):
+            raise RuntimeError("Budget exceeded for chat request")
+
+    response = client.chat.completions.create(
+        model=model,
+        messages=messages,  # type: ignore[arg-type]
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
+    content = response.choices[0].message.content or ""
+    return content.strip()
+
+
+def main() -> None:
+    """Launch the Streamlit conversation UI."""
+    st.title("LLM Chat")
+
+    if "messages" not in st.session_state:
+        st.session_state.messages = []  # type: ignore[assignment]
+
+    for msg in st.session_state.messages:  # type: ignore[attr-defined]
+        with st.chat_message(msg["role"]):
+            st.write(msg["content"])
+
+    if prompt := st.chat_input("Send a message"):
+        st.session_state.messages.append({"role": "user", "content": prompt})  # type: ignore[attr-defined]
+        with st.spinner("Thinking..."):
+            reply = run_openai_chat(st.session_state.messages)
+        st.session_state.messages.append({"role": "assistant", "content": reply})  # type: ignore[attr-defined]
+        with st.chat_message("assistant"):
+            st.write(reply)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- implement new Streamlit-based chat interface for chatting with the configured OpenAI model
- enforce budget tracking and use config-driven API key
- document module purpose in `gui.chat_gui.purpose.md`

## Testing
- `ruff check src/gui/chat_gui.py`
- `mypy src/gui/chat_gui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ffe73aec88323979985e92f25cff1