### PR TITLE
Add parse CLI and path overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ print(store.inject_memory(summary, ["intro"]))
 
 |Command|Purpose|
 |---|---|
-|`kairos parse`|Parse `.pdf`, `.docx`, or `.txt`|
+|`kairos parse`|Parse a file or directory into `.txt`|
 |`kairos classify`|Summarize & generate metadata|
 |`kairos embed all`|Generate document embeddings|
 |`kairos search`|Query the FAISS index|

--- a/purpose_files/cli.parse.purpose.md
+++ b/purpose_files/cli.parse.purpose.md
@@ -1,0 +1,34 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+
+# Module: cli.parse
+# @ai-path: cli.parse
+# @ai-source-file: parse.py
+# @ai-role: CLI Entrypoint
+# @ai-intent: "Convert raw files to parsed text with configurable paths."
+
+> Offers a `parse` command that writes `.txt` files and stub metadata.
+
+### 🎯 Intent & Responsibility
+- Allow users to parse individual files or entire directories.
+- Provide optional overrides for PathConfig directories.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | input_path | Path | File or folder to parse |
+| 📥 In | parsed_name | str | Optional name override for single file |
+| 📥 In | root/raw_dir/parsed_dir/metadata_dir | Path | Optional path overrides |
+| 📤 Out | stub.json | File | Metadata stub linking raw and parsed files |
+
+### 🔗 Dependencies
+- `core.storage.upload_local.prepare_document_for_processing`
+- `core.config.config_registry.get_path_config`
+
+### 🗣 Dialogic Notes
+- Path override logic mirrors upcoming GUI workflow needs.

--- a/purpose_files/cli.pipeline.purpose.md
+++ b/purpose_files/cli.pipeline.purpose.md
@@ -1,0 +1,39 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+
+# Module: cli.pipeline
+# @ai-path: cli.pipeline
+# @ai-source-file: pipeline.py
+# @ai-role: CLI Entrypoint
+# @ai-intent: "Run full or partial document processing pipelines via Typer."
+
+> Exposes a single `run_all` command that uploads, classifies, embeds and clusters documents with optional path overrides.
+
+### 🎯 Intent & Responsibility
+- Provide an end-to-end ingestion pipeline from CLI.
+- Allow path config overrides for GUI or alternative deployments.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | input_dir | Path | Folder of raw documents |
+| 📥 In | chunked | bool | Classification chunk mode |
+| 📥 In | segmentation | str | "semantic" or "paragraph" |
+| 📥 In | method | str | Embedding source text |
+| 📥 In | cluster_method | str | Clustering algorithm |
+| 📥 In | model | str | Model for labeling |
+| 📥 In | root/raw_dir/parsed_dir/metadata_dir/output_dir | Path | Optional path overrides |
+| 📤 Out | cluster_output | Folder | CSV/PNG cluster exports |
+
+### 🔗 Dependencies
+- `scripts.pipeline.run_full_pipeline`
+- `core.clustering.clustering_steps.run_all_steps`
+- `core.config.config_registry.get_path_config`
+
+### 🗣 Dialogic Notes
+- Designed for automation and future GUI-driven pipelines.

--- a/purpose_files/core.storage.upload_local.purpose.md
+++ b/purpose_files/core.storage.upload_local.purpose.md
@@ -1,0 +1,34 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+
+# Module: core.storage.upload_local
+# @ai-path: core.storage.upload_local
+# @ai-source-file: upload_local.py
+# @ai-role: Local Ingestion Utility
+# @ai-intent: "Convert documents to text and save stubs on the local filesystem."
+
+> Provides helper functions to parse raw files into `.txt` and generate stub metadata.
+
+### 🎯 Intent & Responsibility
+- Prepare local documents for classification workflows.
+- Accept optional `PathConfig` overrides for flexible directory layout.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | file_path | Path | Path to the source file |
+| 📥 In | parsed_name | str | Optional name for `.txt` output |
+| 📥 In | paths | PathConfig | Optional directory configuration |
+| 📤 Out | stub | dict | Mapping of raw and parsed file paths |
+
+### 🔗 Dependencies
+- `core.parsing.extract_text`
+- `core.config.config_registry.get_path_config`
+
+### 🗣 Dialogic Notes
+- Called by CLI utilities and pipeline steps during ingestion.

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -5,6 +5,7 @@ import cli.classify as classify
 import cli.cluster as cluster
 import cli.embed as embed
 import cli.pipeline as pipeline
+import cli.parse as parse
 import cli.tokens as tokens
 import cli.search as search
 import cli.agent as agent
@@ -19,6 +20,7 @@ app.add_typer(batch_ops.app, name="batch")
 app.add_typer(embed.app, name="embed")
 app.add_typer(cluster.app, name="cluster")
 app.add_typer(pipeline.app, name="pipeline")
+app.add_typer(parse.app, name="parse")
 app.add_typer(tokens.app, name="tokens")
 app.add_typer(search.app, name="search")
 app.add_typer(agent.app, name="agent")

--- a/src/cli/parse.py
+++ b/src/cli/parse.py
@@ -1,0 +1,44 @@
+import typer
+from pathlib import Path
+from core.config.config_registry import get_path_config
+from core.config.path_config import PathConfig
+from core.storage.upload_local import prepare_document_for_processing
+
+app = typer.Typer(help="Parse documents into text with optional path overrides")
+
+
+def _resolve_paths(root: Path | None, raw: Path | None, parsed: Path | None, metadata: Path | None) -> PathConfig:
+    base = get_path_config()
+    return PathConfig(
+        root=root or base.root,
+        raw=raw or base.raw,
+        parsed=parsed or base.parsed,
+        metadata=metadata or base.metadata,
+        output=base.output,
+        vector=base.vector,
+        schema=base.schema,
+        semantic_chunking=base.semantic_chunking,
+    )
+
+
+@app.command()
+def run(
+    input_path: Path = typer.Argument(..., exists=True, readable=True),
+    parsed_name: str | None = typer.Option(None, help="Custom name for single file"),
+    root: Path | None = typer.Option(None, help="Override root directory"),
+    raw_dir: Path | None = typer.Option(None, help="Raw documents directory"),
+    parsed_dir: Path | None = typer.Option(None, help="Parsed documents directory"),
+    metadata_dir: Path | None = typer.Option(None, help="Metadata directory"),
+):
+    """Parse a file or all files in a directory."""
+    paths = _resolve_paths(root, raw_dir, parsed_dir, metadata_dir)
+
+    if input_path.is_dir():
+        for file in sorted(input_path.glob("*")):
+            prepare_document_for_processing(file, paths=paths)
+    else:
+        prepare_document_for_processing(input_path, parsed_name=parsed_name, paths=paths)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/cli/pipeline.py
+++ b/src/cli/pipeline.py
@@ -5,9 +5,30 @@ import typer
 
 from core.clustering.clustering_steps import run_all_steps
 from core.config.config_registry import get_path_config
+from core.config.path_config import PathConfig
 from scripts.pipeline import run_full_pipeline
 
 app = typer.Typer()
+
+
+def _resolve_paths(
+    root: Path | None,
+    raw: Path | None,
+    parsed: Path | None,
+    metadata: Path | None,
+    output: Path | None,
+) -> PathConfig:
+    base = get_path_config()
+    return PathConfig(
+        root=root or base.root,
+        raw=raw or base.raw,
+        parsed=parsed or base.parsed,
+        metadata=metadata or base.metadata,
+        output=output or base.output,
+        vector=base.vector,
+        schema=base.schema,
+        semantic_chunking=base.semantic_chunking,
+    )
 
 @app.command()
 def run_all(
@@ -16,7 +37,12 @@ def run_all(
     segmentation: str = "semantic",
     method: str = "summary",
     cluster_method: str = "hdbscan",
-    model: str = "gpt-4"
+    model: str = "gpt-4",
+    root: Path | None = typer.Option(None, help="Override root directory"),
+    raw_dir: Path | None = typer.Option(None, help="Raw documents directory"),
+    parsed_dir: Path | None = typer.Option(None, help="Parsed documents directory"),
+    metadata_dir: Path | None = typer.Option(None, help="Metadata directory"),
+    output_dir: Path | None = typer.Option(None, help="Output directory"),
 ):
     """
     Full ingestion + clustering pipeline:
@@ -25,7 +51,7 @@ def run_all(
     3. Embed
     4. Cluster, label, export
     """
-    paths = get_path_config()
+    paths = _resolve_paths(root, raw_dir, parsed_dir, metadata_dir, output_dir)
 
     # Steps 1–3
     run_full_pipeline(
@@ -34,6 +60,7 @@ def run_all(
         method=method,
         overwrite=True,
         segmentation=segmentation,
+        paths=paths,
     )
 
     # Step 4
@@ -42,5 +69,5 @@ def run_all(
         metadata_dir=paths.metadata,
         out_dir=paths.output / "cluster_output",
         method=cluster_method,
-        model=model
+        model=model,
     )

--- a/src/core/storage/upload_local.py
+++ b/src/core/storage/upload_local.py
@@ -5,24 +5,24 @@ from core.config.config_registry import get_path_config
 from core.config.path_config import PathConfig
 from core.parsing.extract_text import extract_text
 
-paths = get_path_config()
-
 def prepare_document_for_processing(
     file_path: Path,
-    parsed_name: str = None,
+    parsed_name: str | None = None,
+    paths: PathConfig | None = None,
 ) -> dict:
     """
     Convert a raw document into parsed text and save a stub locally.
 
     Args:
         file_path (Path): Full path to the raw file
-        parsed_name (str): Optional override for parsed .txt filename
-        paths (PathConfig): Directory configuration
+        parsed_name (str | None): Optional override for parsed .txt filename
+        paths (PathConfig | None): Directory configuration override
 
     Returns:
         dict: Stub metadata linking source and parsed files
     """
-    file_path = Path(file_path) 
+    file_path = Path(file_path)
+    paths = paths or get_path_config()
     paths.raw.mkdir(parents=True, exist_ok=True)
     paths.parsed.mkdir(parents=True, exist_ok=True)
     paths.metadata.mkdir(parents=True, exist_ok=True)
@@ -61,10 +61,11 @@ def prepare_document_for_processing(
 
 def upload_file(
     file_path: Path,
-    parsed_name: str = None,
+    parsed_name: str | None = None,
+    paths: PathConfig | None = None,
 ) -> dict:
     """
     Alias for prepare_document_for_processing.
     Maintained for compatibility with legacy calls.
     """
-    return prepare_document_for_processing(file_path, parsed_name)
+    return prepare_document_for_processing(file_path, parsed_name, paths)

--- a/src/scripts/pipeline.py
+++ b/src/scripts/pipeline.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 
 from core.config.config_registry import get_path_config
+from core.config.path_config import PathConfig
 from core.embeddings.embedder import generate_embeddings
 from core.workflows.main_commands import classify, upload_and_prepare
 
@@ -12,6 +13,7 @@ def run_full_pipeline(
     overwrite: bool = True,
     method: str = "summary",
     segmentation: str = "semantic",
+    paths: PathConfig | None = None,
 ):
     """
     Full ingestion pipeline:
@@ -25,12 +27,12 @@ def run_full_pipeline(
         overwrite (bool): Reclassify even if .meta.json exists
         method (str): Text source for embeddings: parsed, summary, raw, meta
     """
-    paths = get_path_config()
+    paths = paths or get_path_config()
 
     print("📤 Uploading and parsing raw files...")
     for file in sorted(input_dir.glob("*")):
         try:
-            upload_and_prepare(file)
+            upload_and_prepare(file, paths=paths)
         except Exception as e:
             print(f"❌ Upload failed: {file.name} — {e}")
 
@@ -42,11 +44,16 @@ def run_full_pipeline(
             print(f"⏭️ Skipping {name} (already classified)")
             continue
         try:
-            classify(name, chunked=chunked, segmentation=segmentation)
+            classify(name, chunked=chunked, segmentation=segmentation, paths=paths)
             print(f"✅ {name} classified")
         except Exception as e:
             print(f"❌ Classification failed: {name} — {e}")
 
     print("📊 Generating embeddings and updating vector index...")
-    generate_embeddings(method=method, segment_mode=paths.semantic_chunking)
+    generate_embeddings(
+        source_dir=paths.parsed if method != "raw" else paths.raw,
+        method=method,
+        out_path=paths.root / "rich_doc_embeddings.json",
+        segment_mode=paths.semantic_chunking,
+    )
     print("✅ Pipeline complete.")


### PR DESCRIPTION
## Summary
- add `parse` CLI command to convert files to text with overrideable paths
- allow flexible path overrides for the pipeline command
- update upload_local and main_commands to accept `PathConfig`
- refactor scripts pipeline to pass path config and embed options
- document new commands in README
- create purpose files for new CLI and storage modules

## Testing
- `ruff check src/cli/parse.py src/cli/pipeline.py src/cli/main.py src/core/storage/upload_local.py src/scripts/pipeline.py src/core/workflows/main_commands.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688003afbe8c83238d0ab17a5ded52cd