### PR TITLE
Add planning stubs for insurance verification workflow

### DIFF
--- a/intents/2025-08-04__langchain_mcp_pipeline.intent.md
+++ b/intents/2025-08-04__langchain_mcp_pipeline.intent.md
@@ -1,0 +1,4 @@
+- context: Adding planning scaffolds for insurance verification pipeline.
+- decision: Introduced `.purpose.md` stubs for LLM router, insurance parser, and workflow.
+- rationale: Need LangChain/MCP compatibility and support for local Mistral 7B and Bedrock models before implementing extraction logic.
+- open-questions: Define mapping doc schema; evaluate latency of local models; MCP tool invocation requirements.

--- a/purpose_files/core.llm.langchain_router.purpose.md
+++ b/purpose_files/core.llm.langchain_router.purpose.md
@@ -1,0 +1,49 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+
+- @ai-path: core.llm.langchain_router
+- @ai-source-file: core/llm/langchain_router.py
+- @ai-role: adapter
+- @ai-intent: "Route LLM calls to local Mistral 7B or Amazon Bedrock models through LangChain and MCP interfaces."
+- @schema-version: 0.2
+- @ai-generated: true
+- @human-reviewed: false
+- @ai-risk-pii: high
+- @ai-risk-performance: "Local models may respond slowly; Bedrock incurs network latency."
+
+# Module: core.llm.langchain_router
+> Unified gateway translating generic generation requests into LangChain runs against local or Bedrock-hosted models.
+
+### 🎯 Intent & Responsibility
+- Provide a single `generate` function accepting chat-style messages and model metadata.
+- Normalize responses into `{text, tokens_used, provider}`.
+- Expose MCP-compatible streaming hooks and cost logging via `BudgetTracker`.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | messages | List[Dict[str, str]] | Conversation history `{role, content}` |
+| 📥 In | model | str | Model identifier (`mistral-7b`, `bedrock:anthropic.claude`) |
+| 📥 In | config | RemoteConfig | Credentials, runtime flags |
+| 📤 Out | result | Dict[str, Any] | `{text: str, tokens_used: int, provider: str}` |
+
+### 🔗 Dependencies
+- `langchain`
+- `boto3` for Amazon Bedrock
+- local model runtime (`ctransformers`, `ollama`, etc.)
+- `core.utils.budget_tracker`
+
+### 🤝 Integration Points
+- Used by `core.parsing.insurance_verification` for field extraction.
+- Accessible to `core.agent_hub` sessions for conversational reasoning.
+- Shares cost metrics with global `BudgetTracker`.
+
+### 🗣 Dialogic Notes
+- @ai-used-by: core.parsing.insurance_verification
+- @ai-downstream: core.workflows.insurance_verification
+- @ai-role: architect

--- a/purpose_files/core.parsing.insurance_verification.purpose.md
+++ b/purpose_files/core.parsing.insurance_verification.purpose.md
@@ -1,0 +1,46 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+
+- @ai-path: core.parsing.insurance_verification
+- @ai-source-file: core/parsing/insurance_verification.py
+- @ai-role: extractor
+- @ai-intent: "Parse insurance verification documents and map raw text to a canonical policy schema."
+- @schema-version: 0.2
+- @ai-generated: true
+- @human-reviewed: false
+- @ai-risk-pii: high
+- @ai-risk-performance: "Large documents may increase latency; rely on chunking when necessary."
+
+# Module: core.parsing.insurance_verification
+> Ingests PDFs, DOCX, or text forms, compares against a mapping document, and yields normalized insurance metadata.
+
+### 🎯 Intent & Responsibility
+- Load document bytes from varied filetypes and extract raw text.
+- Apply mapping rules and LLM prompts to align fields (policy number, coverages, deductibles, limitations).
+- Emit structured records ready for downstream storage or retrieval.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | file_path | str | Path to insurance verification file |
+| 📥 In | mapping | Dict[str, str] | Field mapping or path to mapping doc |
+| 📥 In | llm | Callable | Generation hook from `langchain_router` |
+| 📤 Out | record | Dict[str, Any] | `{insurer: str, policy_holder: str, coverages: List[Dict[str, Any]], deductibles: Dict[str, str], limitations: List[str]}` |
+
+### 🔗 Dependencies
+- `pdfplumber` / `python-docx` for file parsing
+- `core.llm.langchain_router`
+- `core.utils.budget_tracker`
+
+### 🤝 Integration Points
+- Consumed by `core.workflows.insurance_verification` pipeline.
+- Records may be stored via `core.storage` or indexed by `core.vectorstore`.
+
+### 🗣 Dialogic Notes
+- @ai-used-by: core.workflows.insurance_verification
+- @ai-role: extractor

--- a/purpose_files/core.workflows.insurance_verification.purpose.md
+++ b/purpose_files/core.workflows.insurance_verification.purpose.md
@@ -1,0 +1,47 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+
+- @ai-path: core.workflows.insurance_verification
+- @ai-source-file: core/workflows/insurance_verification.py
+- @ai-role: pipeline
+- @ai-intent: "Orchestrate end-to-end extraction of standardized insurance data from heterogeneous forms."
+- @schema-version: 0.2
+- @ai-generated: true
+- @human-reviewed: false
+- @ai-risk-pii: high
+- @ai-risk-performance: "Throughput dependent on LLM speed and document size."
+
+# Module: core.workflows.insurance_verification
+> High-level workflow that loads verification files, invokes the parser, and persists normalized policy records.
+
+### 🎯 Intent & Responsibility
+- Iterate over one or more input files and associated mapping configs.
+- Delegate extraction to `core.parsing.insurance_verification` with appropriate LLM settings.
+- Store or return aggregated records for downstream analysis or search.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | files | List[str] | Paths to verification forms |
+| 📥 In | mapping | Dict[str, str] | Mapping configuration shared across files |
+| 📥 In | model | str | Target model identifier for `langchain_router` |
+| 📤 Out | records | List[Dict[str, Any]] | List of standardized policy dictionaries |
+
+### 🔗 Dependencies
+- `core.parsing.insurance_verification`
+- `core.llm.langchain_router`
+- `core.storage.upload_local` or similar persistence layer
+
+### 🤝 Integration Points
+- Upstream CLI command may call this pipeline.
+- Downstream vector store or metadata modules consume resulting records.
+- Potential agent-hub role to validate extracted fields.
+
+### 🗣 Dialogic Notes
+- @ai-role: orchestrator
+- @ai-downstream: core.vectorstore.faiss_store


### PR DESCRIPTION
## Summary
- scaffold LangChain/MCP LLM router for local or Bedrock models
- outline insurance verification parser and workflow modules
- capture design intent for upcoming pipeline

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689132542c1c8323917d45dd9484134e