### PR TITLE
Fix remote config path for GUI

### DIFF
--- a/purpose_files/gui.chat_gui.purpose.md
+++ b/purpose_files/gui.chat_gui.purpose.md
@@ -35,12 +35,12 @@
 ### 🔗 Dependencies
 - `streamlit`
 - `openai`, `tiktoken`
-- `core.config.remote_config.RemoteConfig`
+- `core.config.config_registry.get_remote_config`
 - `core.utils.budget_tracker.get_budget_tracker`
 
 ### 🗣 Dialogic Notes
 - Launch with `streamlit run chat_gui.py`.
-- Requires `core/config/remote_config.json` containing `openai_api_key`.
+- Requires `src/core/config/remote_config.json` containing `openai_api_key`, loaded via `config_registry`.
 - Designed for quick experiments; no retrieval or memory injection yet.
 
 ### 9 Pipeline Integration

--- a/src/core/config/remote_config.py
+++ b/src/core/config/remote_config.py
@@ -8,7 +8,7 @@ Role: Load remote service settings for AWS, OpenAI, and future integrations.
 - Keeps setup user-friendly for non-developers
 
 📦 Inputs:
-- remote_config.json
+- remote_config.json (located next to this module)
 
 📤 Outputs:
 - RemoteConfig object with properties like bucket, region, API keys
@@ -66,7 +66,7 @@ class RemoteConfig:
         )
 
     @classmethod
-    def from_file(cls, config_path: Union[str, Path] = Path("core/config/remote_config.json")):
+    def from_file(cls, config_path: Union[str, Path] = Path(__file__).parent / "remote_config.json"):
         """
         Load a RemoteConfig from a JSON file.
 

--- a/src/gui/chat_gui.py
+++ b/src/gui/chat_gui.py
@@ -8,7 +8,7 @@ import streamlit as st  # type: ignore
 import tiktoken
 from openai import OpenAI
 
-from core.config.remote_config import RemoteConfig  # type: ignore
+from core.config.config_registry import get_remote_config
 from core.llm.invoke import LLM_COMPLETION_COST_PER_1K, LLM_PROMPT_COST_PER_1K  # type: ignore
 from core.utils.budget_tracker import get_budget_tracker  # type: ignore
 
@@ -21,7 +21,8 @@ def run_openai_chat(
     api_key: str | None = None,
 ) -> str:
     """Send conversation history to OpenAI and return the assistant reply."""
-    client = OpenAI(api_key=api_key or RemoteConfig.from_file().openai_api_key)
+    remote = get_remote_config()
+    client = OpenAI(api_key=api_key or remote.openai_api_key)
     tracker = get_budget_tracker()
     if tracker:
         enc = tiktoken.encoding_for_model(model)


### PR DESCRIPTION
## Summary
- use get_remote_config in chat GUI
- default `RemoteConfig.from_file()` to look next to module
- document GUI's config loading

## Testing
- `pip install tiktoken openai streamlit`
- `pip install faiss-cpu`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688009c294b483239c982f73b0a45a00