### PR TITLE
feat: centralize logging across modules

### DIFF
--- a/purpose_files/core.logger.purpose.md
+++ b/purpose_files/core.logger.purpose.md
@@ -1,0 +1,48 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+
+# Module: core.logger
+
+- @ai-path: core.logger
+- @ai-source-file: src/core/logger.py
+- @ai-role: utility
+- @ai-intent: "Configure root logging once and provide module-scoped loggers."
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @human-reviewed: false
+- @schema-version: 0.2
+
+## 🎯 Intent & Responsibility
+- Initialize the Python logging subsystem with repository defaults (INFO level, DEBUG via `LOG_LEVEL`).
+- Serve as the single entrypoint for retrieving module-scoped loggers across CLI tools, pipelines, and tests.
+- Preserve compatibility for legacy imports via `core.utils.logger` wrappers.
+
+## 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | default_level | `str` | Optional override for baseline logging level (used by `configure_logging`). |
+| 📥 In | name | `Optional[str]` | Logger namespace requested by callers. |
+| 📥 In | LOG_LEVEL | `env str` | Environment variable toggling verbosity (e.g., `DEBUG`). |
+| 📤 Out | logger | `logging.Logger` | Configured logger instance with shared format and level. |
+
+## 🔗 Dependencies & Coordination
+- Uses Python's `logging` module for handler configuration.
+- Reads `os.environ['LOG_LEVEL']` to respect runtime verbosity controls.
+- Downstream modules: `core.agent_hub`, `cli.batch_ops`, `scripts.pipeline`, clustering utilities, storage helpers, and tests (via `get_logger`).
+- Coordination mechanics: `get_logger` is invoked at module import time; it idempotently calls `configure_logging` to ensure the root logger is ready before emitting records.
+- Integration with ecosystem: `core.utils.logger` re-exports these helpers for backwards compatibility, supporting existing agents and toolchains relying on the legacy path.
+
+## ⚠️ Risks & Notes
+- @ai-risk-performance: "Minimal; configuration happens once per process but avoid redundant handler installs."
+- @ai-risk-integration: Misconfigured environment values (e.g., invalid `LOG_LEVEL`) fall back to INFO; note in drift reviews if more validation becomes necessary.
+- @ai-used-by: `CLI` commands, clustering exporters, storage utilities, Lambda orchestrators, and regression tests.
+
+## 🌐 Ecosystem Anchoring
+- @ai-role-map: `{executor: emits structured logs, memory_architect: leverages logs for drift reviews}`
+- @dialogic-notes: "Central logger underpins observability for cooperative agents and pipeline CLIs; ensures Run cadence outputs are captured consistently."

--- a/purpose_files/core.utils.logger.purpose.md
+++ b/purpose_files/core.utils.logger.purpose.md
@@ -5,11 +5,11 @@
 # @ai-role: utility
 # @ai-intent: "Provide a thin wrapper for consistent, environment-aware logging across modules."
 
-> Provide a simple helper to configure and retrieve Python loggers with a common format.
+> Provide a compatibility shim that re-exports the central logging helpers.
 
 ### 🎯 Intent & Responsibility
-- Ensure consistent log formatting across modules.
-- Respect `LOG_LEVEL` environment variable for verbosity control.
+- Maintain backwards compatibility for modules still importing `core.utils.logger`.
+- Proxy calls to `core.logger` so configuration logic stays centralized.
 
 ### 📥 Inputs & 📤 Outputs
 | Direction | Name        | Type            | Brief Description |
@@ -19,7 +19,7 @@
 | 📤 Out    | logger      | logging.Logger  | Configured logger object |
 
 ### 🔗 Dependencies
-- `logging`, `os`
+- `core.logger` for actual setup and retrieval
 
 ### 🗣 Dialogic Notes
 - Called by `core.embeddings.embedder` for detailed error reporting.

--- a/src/cli/batch_ops.py
+++ b/src/cli/batch_ops.py
@@ -53,10 +53,15 @@ from pathlib import Path
 import typer
 
 from core.config.config_registry import get_path_config
-from core.workflows.main_commands import (classify, pipeline_from_upload,
-                                          upload_and_prepare)
+from core.logger import get_logger
+from core.workflows.main_commands import (
+    classify,
+    pipeline_from_upload,
+    upload_and_prepare,
+)
 
 app = typer.Typer()
+logger = get_logger(__name__)
 
 
 @app.command()
@@ -72,15 +77,15 @@ def classify_all(
         meta_path = paths.metadata / f"{name}.meta.json"
 
         if meta_path.exists() and not overwrite:
-            print(f"🟡 Skipping {name} (already classified)")
+            logger.info("Skipping %s (already classified)", name)
             continue
 
         try:
-            print(f"🔍 Classifying {name}...")
+            logger.info("Classifying %s...", name)
             classify(name, chunked=chunked, segmentation=segmentation)
-            print(f"✅ Done: {name}")
+            logger.info("Done: %s", name)
         except Exception as e:
-            print(f"❌ Error: {name} — {e}")
+            logger.error("Error: %s — %s", name, e)
 
 
 @app.command()
@@ -88,10 +93,10 @@ def upload_all(directory: Path):
     """Upload and parse all files in the given local directory."""
     for file in sorted(directory.glob("*")):
         try:
-            print(f"📤 Uploading {file.name}...")
+            logger.info("Uploading %s...", file.name)
             upload_and_prepare(file)
         except Exception as e:
-            print(f"❌ Failed on {file.name}: {e}")
+            logger.error("Failed on %s: %s", file.name, e)
 
 
 @app.command()
@@ -103,13 +108,13 @@ def ingest_all(
     """Full pipeline: upload, parse, classify for all files in directory."""
     for file in sorted(directory.glob("*")):
         try:
-            print(f"🚀 Ingesting {file.name}...")
+            logger.info("Ingesting %s...", file.name)
             parsed_name = None  # Optional override name
             result = pipeline_from_upload(
                 file,
                 parsed_name=parsed_name,
                 segmentation=segmentation,
             )
-            print(f"✅ Metadata: {result.get('summary', '')[:100]}...")
+            logger.info("Metadata: %s...", result.get("summary", "")[:100])
         except Exception as e:
-            print(f"❌ Error during ingestion of {file.name}: {e}")
+            logger.error("Error during ingestion of %s: %s", file.name, e)

--- a/src/cli/classify.py
+++ b/src/cli/classify.py
@@ -43,9 +43,11 @@ It is intended for fast integration into scalable document processing pipelines.
 
 import typer
 
+from core.logger import get_logger
 from core.workflows.main_commands import classify
 
 app = typer.Typer()
+logger = get_logger(__name__)
 
 
 @app.command()
@@ -56,5 +58,5 @@ def classify_one(
 ):
     """Classify a single document (optionally in chunked mode)."""
     result = classify(name, chunked=chunked, segmentation=segmentation)
-    print("✅ Metadata saved.")
-    print(result)
+    logger.info("Metadata saved.")
+    logger.info("%s", result)

--- a/src/cli/organize.py
+++ b/src/cli/organize.py
@@ -52,7 +52,11 @@ import shutil
 from pathlib import Path
 from typing import Dict
 
+from core.logger import get_logger
 from core.metadata.io import load_metadata
+
+
+logger = get_logger(__name__)
 
 
 def organize_file(
@@ -76,7 +80,7 @@ def organize_file(
     """
     meta_path = meta_dir / f"{name}.meta.json"
     if not meta_path.exists():
-        print(f"[red]No metadata found for {name}[/red]")
+        logger.error("[red]No metadata found for %s[/red]", name)
         return
 
     meta = load_metadata(name, meta_dir)
@@ -94,9 +98,9 @@ def organize_file(
     parsed_dst = organized_path / parsed_file
     if parsed_src.exists():
         parsed_src.replace(parsed_dst)
-        print(f"[green]Moved parsed file to {parsed_dst}[/green]")
+        logger.info("[green]Moved parsed file to %s[/green]", parsed_dst)
     else:
-        print(f"[yellow]Parsed file missing: {parsed_src}[/yellow]")
+        logger.warning("[yellow]Parsed file missing: %s[/yellow]", parsed_src)
 
     source_file = meta.get("source_file")
     if source_file:
@@ -105,9 +109,9 @@ def organize_file(
         source_dst = organized_path / source_name
         if source_src.exists():
             source_src.replace(source_dst)
-            print(f"[cyan]Moved source file to {source_dst}[/cyan]")
+            logger.info("[cyan]Moved source file to %s[/cyan]", source_dst)
         else:
-            print(f"[yellow]Source file missing: {source_src}[/yellow]")
+            logger.warning("[yellow]Source file missing: %s[/yellow]", source_src)
 
     shutil.copy(meta_path, organized_path / meta_path.name)
-    print(f"[blue]Copied metadata to {organized_path / meta_path.name}[/blue]")
+    logger.info("[blue]Copied metadata to %s[/blue]", organized_path / meta_path.name)

--- a/src/cli/search.py
+++ b/src/cli/search.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 import typer
 
+from core.logger import get_logger
 from core.retrieval.retriever import Retriever
-from core.utils.logger import get_logger
 
 app = typer.Typer()
 logger = get_logger(__name__)
@@ -16,7 +16,7 @@ def semantic(query: str, k: int = 5):
     logger.info("Running semantic search for: %s", query)
     hits = retriever.query(query, k=k)
     for doc_id, score in hits:
-        print(doc_id, f"{score:.3f}")
+        logger.info("%s %.3f", doc_id, score)
 
 
 @app.command("file")
@@ -26,4 +26,4 @@ def semantic_file(file_path: typer.FileText, k: int = 5):
     logger.info("Running semantic search for file: %s", file_path.name)
     hits = retriever.query_file(Path(file_path.name), k=k)
     for doc_id, score in hits:
-        print(doc_id, f"{score:.3f}")
+        logger.info("%s %.3f", doc_id, score)

--- a/src/cli/tokens.py
+++ b/src/cli/tokens.py
@@ -4,11 +4,13 @@ from pathlib import Path
 import typer
 
 from core.analysis.token_stats import TokenStats
+from core.logger import get_logger
 
 # 👇  absolute path to the repo-local default
 DEFAULT_CFG = Path(__file__).parent.parent / "core" / "config" / "path_config.json"
 
 app = typer.Typer(help="Token-count utilities")
+logger = get_logger(__name__)
 
 
 @app.command("summary")
@@ -49,4 +51,5 @@ def summary(
 def recite():
     from zen_of_spite import spite_verses
 
-    print("\n".join(f"• {v}" for v in spite_verses))
+    verses = "\n".join(f"• {v}" for v in spite_verses)
+    logger.info("%s", verses)

--- a/src/core/agent_hub.py
+++ b/src/core/agent_hub.py
@@ -1,6 +1,10 @@
 from typing import Iterable
 
+from core.logger import get_logger
 from core.retrieval.retriever import Retriever
+
+
+logger = get_logger(__name__)
 
 
 class AgentSession:
@@ -21,4 +25,4 @@ def run_agents(prompt: str, roles: Iterable[str]) -> None:
     sessions = [AgentSession(role, retriever) for role in roles]
     for session in sessions:
         result = session.step(prompt)
-        print(session.role, result)
+        logger.info("%s %s", session.role, result)

--- a/src/core/analysis/token_stats.py
+++ b/src/core/analysis/token_stats.py
@@ -4,11 +4,14 @@ Quick token-count and distribution helper for Mosaic files.
 Usage (from code):
 
     from core.analysis.token_stats import TokenStats
+    from core.logger import get_logger
+
     stats = TokenStats.from_glob(
         path_pattern="parsed/**/*.txt",
         tokenizer="tiktoken:gpt-4o-mini"
     )
-    print(stats.describe())
+    logger = get_logger(__name__)
+    logger.info(stats.describe())
 
 The same logic powers the `mosaic tokens` CLI command.
 """
@@ -20,6 +23,11 @@ from statistics import mean, median, quantiles
 from typing import Callable, Dict, List
 
 from transformers import AutoTokenizer
+
+from core.logger import get_logger
+
+
+logger = get_logger(__name__)
 
 # --------------------------------------------------------------------------- #
 #  Registry of tokenizers
@@ -78,7 +86,7 @@ class TokenStats:
             try:
                 counts.append(tk(p.read_text()))
             except Exception as e:
-                print(f"[warn] skipping {p}: {e}")
+                logger.warning("skipping %s: %s", p, e)
 
         return cls(counts=counts, file_paths=paths)
 
@@ -118,5 +126,5 @@ class TokenStats:
             try:
                 counts.append(tk(p.read_text()))
             except Exception as e:
-                print(f"[warn] skipping {p}: {e}")
+                logger.warning("skipping %s: %s", p, e)
         return cls(counts=counts, file_paths=paths)

--- a/src/core/clustering/cluster_helpers.py
+++ b/src/core/clustering/cluster_helpers.py
@@ -9,6 +9,11 @@ import pandas as pd
 import umap
 from sklearn.cluster import SpectralClustering
 
+from core.logger import get_logger
+
+
+logger = get_logger(__name__)
+
 """
 Module: core_lib.clustering.cluster_helpers
 - @ai-path: core_lib.clustering.cluster_helpers
@@ -126,7 +131,7 @@ Provide a short (2–6 words) high-level label for this cluster:"""
         label = response.choices[0].message.content.strip()
         smart_labels[cluster_id] = label
         if preview:
-            print(f"{cluster_id}: {label}")
+            logger.info("%s: %s", cluster_id, label)
     return smart_labels
 
 
@@ -159,7 +164,7 @@ with open("output/cluster_assignments_hdb.json", "w") as f:
 with open("output/cluster_assignments_spectral.json", "w") as f:
     json.dump(assignments_spec, f, indent=2)
 
-print("✅ Cluster maps saved.")
+logger.info("Cluster maps saved.")
 
 # 📊 Label UMAP data
 umap_df["cluster_hdb"] = [assignments_hdb.get(doc.lower(), "Noise") for doc in doc_ids]
@@ -212,7 +217,7 @@ for doc in doc_ids:
         try:
             meta = json.load(f)
         except json.JSONDecodeError:
-            print(f"⚠️ Skipping malformed JSON: {meta_path}")
+            logger.warning("Skipping malformed JSON: %s", meta_path)
             continue
     records.append(
         {
@@ -228,4 +233,4 @@ for doc in doc_ids:
     )
 
 pd.DataFrame(records).to_csv("output/cluster_summary.csv", index=False)
-print("📋 cluster_summary.csv saved.")
+logger.info("cluster_summary.csv saved.")

--- a/src/core/clustering/export.py
+++ b/src/core/clustering/export.py
@@ -59,6 +59,10 @@ from typing import Dict, List
 import pandas as pd
 
 from core.clustering.cluster_utils import plot_umap_clusters
+from core.logger import get_logger
+
+
+logger = get_logger(__name__)
 
 
 def export_cluster_data(
@@ -131,4 +135,4 @@ def export_cluster_data(
 
     # Save PNG
     plot_umap_clusters(df, "cluster_label", "UMAP Clusters", out_dir / "umap_plot.png")
-    print("✅ Cluster results exported.")
+    logger.info("Cluster results exported.")

--- a/src/core/clustering/labeling.py
+++ b/src/core/clustering/labeling.py
@@ -53,6 +53,10 @@ from typing import Dict, List
 from openai import OpenAI
 
 from core.config.config_registry import get_remote_config
+from core.logger import get_logger
+
+
+logger = get_logger(__name__)
 
 
 def label_clusters(
@@ -70,7 +74,7 @@ def label_clusters(
         labels: Cluster assignments (same order as doc_ids)
         metadata_dir: Path to .meta.json files
         model: OpenAI model
-        preview: Whether to print live output
+        preview: Whether to emit live output via logger
 
     Returns:
         cluster_id → label
@@ -110,9 +114,9 @@ def label_clusters(
             label = response.choices[0].message.content.strip()
         except Exception as e:
             label = "Unlabeled"
-            print(f"❌ {cluster_id}: {e}")
+            logger.error("%s labeling failed: %s", cluster_id, e)
         label_map[cluster_id] = label
         if preview:
-            print(f"{cluster_id}: {label}")
+            logger.info("%s: %s", cluster_id, label)
 
     return label_map

--- a/src/core/embeddings/embedder.py
+++ b/src/core/embeddings/embedder.py
@@ -10,7 +10,7 @@ from openai import OpenAI
 
 from core.config.config_registry import get_path_config, get_remote_config
 from core.utils.budget_tracker import get_budget_tracker
-from core.utils.logger import get_logger
+from core.logger import get_logger
 from core.vectorstore.faiss_store import FaissStore
 
 MAX_EMBED_TOKENS = 8191

--- a/src/core/logger.py
+++ b/src/core/logger.py
@@ -1,0 +1,34 @@
+"""Central logging utilities for the Cognitive Scaffolding stack."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+
+_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def configure_logging(default_level: str = "INFO") -> None:
+    """Configure the root logger once using environment-aware settings."""
+
+    level_name = os.getenv("LOG_LEVEL", default_level).upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        logging.basicConfig(level=level, format=_LOG_FORMAT, datefmt=_DATE_FORMAT)
+    else:
+        root_logger.setLevel(level)
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a module-level logger configured with project defaults."""
+
+    configure_logging()
+    return logging.getLogger(name)
+
+
+__all__ = ["configure_logging", "get_logger"]

--- a/src/core/metadata/io_helpers.py
+++ b/src/core/metadata/io_helpers.py
@@ -42,6 +42,7 @@ downloads if necessary. This ensures robust handling of missing or incomplete pa
 import json
 from pathlib import Path
 
+from core.logger import get_logger
 from core_lib.config.remote_config import RemoteConfig
 from core_lib.parsing.extract_text import extract_text
 from core_lib.storage.s3_utils import get_s3_client
@@ -49,6 +50,8 @@ from core_lib.storage.s3_utils import get_s3_client
 remote = RemoteConfig.from_file(
     Path(__file__).parent.parent / "config" / "remote_config.json"
 )
+
+logger = get_logger(__name__)
 
 
 def get_parsed_text(name: str) -> str:
@@ -66,12 +69,12 @@ def get_parsed_text(name: str) -> str:
         raw_path = Path(remote.prefixes["raw"]) / raw_file
 
         if raw_path.exists():
-            print(f"♻️ Re-parsing from raw file: {raw_file}")
+            logger.info("Re-parsing from raw file: %s", raw_file)
             text = extract_text(str(raw_path))
             parsed_path.write_text(text, encoding="utf-8")
             return text
 
-    print(f"⬇️ Downloading parsed file from S3: {name}")
+    logger.info("Downloading parsed file from S3: %s", name)
     s3 = get_s3_client()
     s3.download_file(
         Bucket=remote.bucket_name,

--- a/src/core/metadata/schema.py
+++ b/src/core/metadata/schema.py
@@ -45,8 +45,10 @@ from pathlib import Path
 from jsonschema import validate
 
 from core.config.config_registry import get_path_config
+from core.logger import get_logger
 
 paths = get_path_config()
+logger = get_logger(__name__)
 
 
 def validate_metadata(metadata: dict) -> None:
@@ -62,7 +64,7 @@ def validate_metadata(metadata: dict) -> None:
         FileNotFoundError: If schema path is missing or invalid.
     """
     schema_path = Path(paths.schema)
-    print(f"[schema.py] Using schema path: {schema_path}")
+    logger.info("Using schema path: %s", schema_path)
 
     if not schema_path.exists():
         raise FileNotFoundError(f"Schema file not found at: {schema_path}")

--- a/src/core/parsing/semantic_chunk.py
+++ b/src/core/parsing/semantic_chunk.py
@@ -7,7 +7,7 @@ import umap
 from sklearn.cluster import SpectralClustering
 
 from core.embeddings.embedder import embed_text
-from core.utils.logger import get_logger
+from core.logger import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/core/parsing/topic_segmenter.py
+++ b/src/core/parsing/topic_segmenter.py
@@ -14,7 +14,7 @@ import tiktoken
 import umap
 
 from core.embeddings.embedder import embed_text
-from core.utils.logger import get_logger
+from core.logger import get_logger
 
 from .chunk_text import chunk_text
 from .semantic_chunk import semantic_chunk_text

--- a/src/core/retrieval/retriever.py
+++ b/src/core/retrieval/retriever.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from core.config.config_registry import get_path_config
 from core.embeddings.embedder import MODEL_DIMS, embed_text, get_model_for_dim
-from core.utils.logger import get_logger
+from core.logger import get_logger
 from core.vectorstore.faiss_store import FaissStore
 
 

--- a/src/core/storage/s3_utils.py
+++ b/src/core/storage/s3_utils.py
@@ -46,8 +46,12 @@ Designed to support workflows needing reliable cloud storage and retrieval pipel
 import json
 
 from core.config.remote_config import RemoteConfig
+from core.logger import get_logger
 from core.metadata.schema import validate_metadata
 from core.storage.aws_clients import get_s3_client
+
+
+logger = get_logger(__name__)
 
 
 def save_metadata_s3(bucket: str, key: str, metadata: dict, s3=None) -> None:
@@ -121,10 +125,10 @@ def clear_s3_folders(prefixes: list[str], s3=None) -> None:
     s3 = s3 or get_s3_client()
 
     for prefix in prefixes:
-        print(f"🧹 Clearing {prefix}")
+        logger.info("Clearing %s", prefix)
         response = remote = RemoteConfig.from_file("remote_config.json")
     s3.list_objects_v2(Bucket=remote.bucket_name, Prefix=prefix)
     if "Contents" in response:
         for obj in response["Contents"]:
-            print(f"  Deleting {obj['Key']}")
+            logger.info("Deleting %s", obj["Key"])
             s3.delete_object(Bucket=remote.bucket_name, Key=obj["Key"])

--- a/src/core/storage/upload_local.py
+++ b/src/core/storage/upload_local.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 from core.config.config_registry import get_path_config
 from core.config.path_config import PathConfig
+from core.logger import get_logger
 from core.parsing.extract_text import extract_text
+
+
+logger = get_logger(__name__)
 
 
 def prepare_document_for_processing(
@@ -57,8 +61,8 @@ def prepare_document_for_processing(
     stub_file = paths.metadata / f"{parsed_name}.stub.json"
     stub_file.write_text(json.dumps(stub, indent=2), encoding="utf-8")
 
-    print(f"Saved stub locally: {stub_file}")
-    print(f"Uploaded parsed version to: {dest_parsed}")
+    logger.info("Saved stub locally: %s", stub_file)
+    logger.info("Uploaded parsed version to: %s", dest_parsed)
 
     return stub
 

--- a/src/core/utils/lambda_summary.py
+++ b/src/core/utils/lambda_summary.py
@@ -4,6 +4,7 @@ import time
 
 from config.remote_config import RemoteConfig
 
+from core.logger import get_logger
 from core.storage.aws_clients import get_lambda_client, get_s3_client
 
 """
@@ -52,6 +53,7 @@ It includes retry logic, structured result unpacking, and error handling for mal
 remote = RemoteConfig.from_file()
 
 lambda_client = get_lambda_client(region=remote.region)
+logger = get_logger(__name__)
 
 
 def invoke_summary(s3_filename: str, override_text: str = None) -> str:
@@ -76,7 +78,7 @@ def invoke_summary(s3_filename: str, override_text: str = None) -> str:
             return response["Payload"].read().decode("utf-8")
         except Exception as e:
             wait = 2 + random.random() * 2
-            print(f"[red]Retrying ({attempt+1}/5) after error: {e}[/red]")
+            logger.warning("Retrying (%d/5) after error: %s", attempt + 1, e)
             time.sleep(wait)
 
     return json.dumps({"error": "Exceeded retries", "key": key})

--- a/src/core/utils/logger.py
+++ b/src/core/utils/logger.py
@@ -1,19 +1,8 @@
-import logging
-import os
+"""Backward compatibility wrapper for relocated logging helpers."""
 
+from __future__ import annotations
 
-def setup_logging() -> None:
-    """Configure basic logging once."""
-    level = os.getenv("LOG_LEVEL", "INFO").upper()
-    if not logging.getLogger().handlers:
-        logging.basicConfig(
-            level=getattr(logging, level, logging.INFO),
-            format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
+from core.logger import configure_logging as setup_logging  # noqa: F401
+from core.logger import get_logger
 
-
-def get_logger(name: str) -> logging.Logger:
-    """Return a module-level logger with standard config."""
-    setup_logging()
-    return logging.getLogger(name)
+__all__ = ["setup_logging", "get_logger"]

--- a/src/core/vectorstore/faiss_store.py
+++ b/src/core/vectorstore/faiss_store.py
@@ -5,7 +5,7 @@ from typing import Iterable, List, Tuple
 import faiss
 import numpy as np
 
-from core.utils.logger import get_logger
+from core.logger import get_logger
 
 
 class FaissStore:

--- a/src/tests/test_clustering_from_embeddings.py
+++ b/src/tests/test_clustering_from_embeddings.py
@@ -1,16 +1,22 @@
 import pytest
 
-from core.clustering.clustering_steps import (run_clustering,
-                                              run_dimensionality_reduction,
-                                              run_export, run_labeling)
+from core.clustering.clustering_steps import (
+    run_clustering,
+    run_dimensionality_reduction,
+    run_export,
+    run_labeling,
+)
 from core.config.config_registry import get_path_config
 from core.config.path_config import PathConfig
+from core.logger import get_logger
 from core.workflows.main_commands import classify
+
+logger = get_logger(__name__)
 
 pytest.skip("Skipping heavy clustering test", allow_module_level=True)
 
 def test_clustering_from_embeddings(tmp_path, monkeypatch):
-    print("🧪 Testing clustering from existing embeddings...")
+    logger.info("Testing clustering from existing embeddings...")
     paths = get_path_config()
     embedding_path = paths.root / "rich_doc_embeddings.json"
     metadata_dir = paths.metadata
@@ -19,8 +25,8 @@ def test_clustering_from_embeddings(tmp_path, monkeypatch):
     if not embedding_path.exists() or embedding_path.stat().st_size == 0:
         pytest.skip("embedding file missing")
 
-    print(f"Using {embedding_path} for testing.")
-    print(f"Using {metadata_dir} for testing.")
+    logger.info("Using %s for testing.", embedding_path)
+    logger.info("Using %s for testing.", metadata_dir)
     paths = get_path_config()
     embedding_path = paths.root / "rich_doc_embeddings.json"
     metadata_dir = paths.metadata
@@ -67,7 +73,7 @@ def test_clustering_from_embeddings(tmp_path, monkeypatch):
     assert out_dir.joinpath("cluster_assignments.csv").exists()
     assert out_dir.joinpath("cluster_summary.csv").exists()
     assert out_dir.joinpath("umap_plot.png").exists()
-    print("✅ Clustering from existing embeddings succeeded.")
+    logger.info("Clustering from existing embeddings succeeded.")
 
 
 if __name__ == "__main__":

--- a/src/tools/clean_trace.py
+++ b/src/tools/clean_trace.py
@@ -3,6 +3,11 @@ import re
 import sys
 from pathlib import Path
 
+from core.logger import get_logger
+
+
+logger = get_logger(__name__)
+
 
 def clean_trace_line(line: str) -> str:
     if line.strip().startswith("```") or not line.strip():
@@ -93,10 +98,10 @@ def extract_codex_reasoning(
             for step in reasoning_steps:
                 jf.write(json.dumps(step) + "\n")
 
-    print(f"✅ Extracted {len(reasoning_steps)} reasoning steps")
-    print(f"📝 Markdown: {output_md.name}")
+    logger.info("Extracted %d reasoning steps", len(reasoning_steps))
+    logger.info("Markdown: %s", output_md.name)
     if output_jsonl:
-        print(f"📦 JSONL: {output_jsonl.name}")
+        logger.info("JSONL: %s", output_jsonl.name)
 
 
 def bulk_process_dir(input_dir: Path, output_dir: Path):
@@ -114,11 +119,11 @@ def bulk_process_dir(input_dir: Path, output_dir: Path):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage:")
-        print(
+        logger.error("Usage:")
+        logger.error(
             "  Single file : python clean_trace.py <input_file> <output_md> [<output_jsonl>]"
         )
-        print("  Bulk mode   : python clean_trace.py <input_dir> <output_dir>")
+        logger.error("  Bulk mode   : python clean_trace.py <input_dir> <output_dir>")
         sys.exit(1)
 
     input_path = Path(sys.argv[1])

--- a/src/tools/parse_json_file.py
+++ b/src/tools/parse_json_file.py
@@ -2,6 +2,8 @@ import argparse
 import json
 from pathlib import Path
 
+from core.logger import get_logger
+
 
 def extract_and_parse_text(json_path):
     path = Path(json_path)
@@ -17,6 +19,7 @@ def extract_and_parse_text(json_path):
 
 
 def main():
+    logger = get_logger(__name__)
     parser = argparse.ArgumentParser(
         description="Extract and print the 'text' field from a JSON file."
     )
@@ -25,9 +28,9 @@ def main():
 
     try:
         parsed_text = extract_and_parse_text(args.file)
-        print(parsed_text)
+        logger.info("%s", parsed_text)
     except Exception as e:
-        print(f"Error: {e}")
+        logger.error("Error: %s", e)
 
 
 if __name__ == "__main__":

--- a/src/zen_of_spite.py
+++ b/src/zen_of_spite.py
@@ -1,8 +1,7 @@
 # zen_of_spite.py
-"""
-The Zen of Spite — a manifesto for the fed-up, the betrayed, and the battle-scarred.
-A direct response to 'import this' and the sanctimony of 'Pythonic' dogma.
-"""
+"""The Zen of Spite manifesto output helper."""
+
+from core.logger import get_logger
 
 spite_verses = [
     "There are fifteen inconsistent ways to do anything, and all of them are half-documented.",
@@ -25,6 +24,7 @@ spite_verses = [
 
 
 if __name__ == "__main__":
-    print("\nThe Zen of Spite — Dedicated to everyone who saw through the bullshit:\n")
+    logger = get_logger(__name__)
+    logger.info("The Zen of Spite — Dedicated to everyone who saw through the bullshit:")
     for line in spite_verses:
-        print(f"• {line}")
+        logger.info("• %s", line)


### PR DESCRIPTION
## Summary
- add a central `core.logger` helper with environment-aware configuration and update the module purpose documentation
- replace scattered `print` usage with structured logging across CLI commands, pipelines, storage utilities, clustering helpers, and supporting tools
- refresh compatibility notes for `core.utils.logger` and update scripts/tests to consume the new logger

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*
- `PYTHONPATH=src pytest` *(fails: ModuleNotFoundError: No module named 'tiktoken')*

------
https://chatgpt.com/codex/tasks/task_e_68cdcfc5e3748323bbd17aae07fc22c7