### PR TITLE
Add clustering safeguards and fixture-backed tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,7 @@ config.py
 *.txt
 *.pdf
 *.json
+!tests/fixtures/*.json
 *.xlsx
 *.trace.*
 *.db

--- a/intents/2025-10-06__clustering_safety.intent.md
+++ b/intents/2025-10-06__clustering_safety.intent.md
@@ -1,0 +1,6 @@
+@ai-intent: Safeguard clustering pipeline against missing deps and degenerate embedding payloads
+
+- Normalized embedding loader to coerce dict payloads and always emit 2D arrays, preventing 1D/empty crashes in downstream reducers.
+- Added guardrails to clustering algorithms for zero/one sample cases and dependency-less environments; tightened UMAP neighbor bounds.
+- Wrapped optional imports (tiktoken, umap, hdbscan, faiss) with runtime errors so tests can skip gracefully instead of failing on import.
+- Introduced fixture-driven clustering test harness that bypasses remote configs/OpenAI while still exercising export outputs.

--- a/src/core/clustering/algorithms.py
+++ b/src/core/clustering/algorithms.py
@@ -1,22 +1,47 @@
 # core/clustering/algorithms.py
 from typing import Literal
 
-import hdbscan
 import numpy as np
-import umap
 from sklearn.cluster import SpectralClustering
+
+try:
+    import hdbscan  # type: ignore[import]
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    hdbscan = None  # type: ignore[assignment]
+
+try:
+    import umap  # type: ignore[import]
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    umap = None  # type: ignore[assignment]
 
 
 def reduce_dimensions(
     X: np.ndarray, n_neighbors: int = 15, min_dist: float = 0.1, random_state: int = 42
 ) -> np.ndarray:
-    """
-    Apply UMAP to reduce high-dimensional data to 2D.
-    """
+    """Apply UMAP to reduce high-dimensional data to 2D with guardrails."""
+
+    if umap is None:  # pragma: no cover - exercised when dependency missing
+        raise ModuleNotFoundError(
+            "umap-learn is required for dimensionality reduction but is not installed."
+        )
+
+    embeddings = np.asarray(X, dtype=float)
+    if embeddings.ndim == 0:
+        embeddings = embeddings.reshape(0, 0)
+    elif embeddings.ndim == 1:
+        embeddings = embeddings.reshape(1, -1)
+
+    n_samples = embeddings.shape[0]
+    if n_samples == 0:
+        return np.empty((0, 2), dtype=float)
+    if n_samples == 1:
+        return np.zeros((1, 2), dtype=float)
+
+    adjusted_neighbors = max(1, min(n_neighbors, 15, n_samples - 1))
     reducer = umap.UMAP(
-        n_neighbors=n_neighbors, min_dist=min_dist, random_state=random_state
+        n_neighbors=adjusted_neighbors, min_dist=min_dist, random_state=random_state
     )
-    return reducer.fit_transform(X)
+    return reducer.fit_transform(embeddings)
 
 
 def cluster_embeddings(
@@ -39,16 +64,41 @@ def cluster_embeddings(
     Returns:
         np.ndarray: Cluster labels
     """
+    embeddings = np.asarray(X, dtype=float)
+    if embeddings.ndim == 0:
+        embeddings = embeddings.reshape(0, 0)
+    elif embeddings.ndim == 1:
+        embeddings = embeddings.reshape(1, -1)
+
+    n_samples = embeddings.shape[0]
+    if n_samples == 0:
+        return np.empty((0,), dtype=int)
+
     if method == "hdbscan":
-        model = hdbscan.HDBSCAN(min_cluster_size=min_cluster_size, prediction_data=True)
-        return model.fit_predict(X)
-    elif method == "spectral":
+        if hdbscan is None:  # pragma: no cover - optional dependency
+            raise ModuleNotFoundError(
+                "hdbscan is required for HDBSCAN clustering but is not installed."
+            )
+
+        if n_samples < max(1, min_cluster_size):
+            return np.zeros((n_samples,), dtype=int)
+
+        model = hdbscan.HDBSCAN(
+            min_cluster_size=min_cluster_size, prediction_data=True
+        )
+        return model.fit_predict(embeddings)
+
+    if method == "spectral":
+        if n_samples <= 2:
+            return np.zeros((n_samples,), dtype=int)
+
+        cluster_count = max(2, min(n_clusters, n_samples - 1))
         model = SpectralClustering(
-            n_clusters=n_clusters,
+            n_clusters=cluster_count,
             affinity="nearest_neighbors",
             assign_labels="kmeans",
             random_state=random_state,
         )
-        return model.fit_predict(X)
-    else:
-        raise ValueError(f"Unsupported clustering method: {method}")
+        return model.fit_predict(embeddings)
+
+    raise ValueError(f"Unsupported clustering method: {method}")

--- a/src/core/vectorstore/faiss_store.py
+++ b/src/core/vectorstore/faiss_store.py
@@ -2,8 +2,12 @@ import hashlib
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
-import faiss
 import numpy as np
+
+try:
+    import faiss  # type: ignore[import]
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    faiss = None  # type: ignore[assignment]
 
 from core.logger import get_logger
 
@@ -12,6 +16,11 @@ class FaissStore:
     """Lightweight wrapper around a FAISS index with ID mapping."""
 
     def __init__(self, dim: int, path: Path):
+        if faiss is None:  # pragma: no cover - optional dependency
+            raise ModuleNotFoundError(
+                "faiss is required for FaissStore but is not installed."
+            )
+
         self.dim = dim
         self.path = path
         self.logger = get_logger(__name__)

--- a/tests/fixtures/rich_doc_embeddings.json
+++ b/tests/fixtures/rich_doc_embeddings.json
@@ -1,0 +1,350 @@
+{
+  "doc_00": {
+    "embedding": [
+      0.0,
+      0.05,
+      0.1,
+      0.15,
+      0.2,
+      0.25
+    ],
+    "metadata": {
+      "summary": "Summary for document 0",
+      "topics": [
+        "topic-0",
+        "topic-1"
+      ],
+      "tags": [
+        "test",
+        "fixture"
+      ],
+      "themes": [
+        "demo"
+      ],
+      "priority": 1,
+      "tone": "informational",
+      "stage": "draft",
+      "depth": "surface",
+      "category": "standard"
+    }
+  },
+  "doc_01": {
+    "embedding": [
+      0.1,
+      0.15,
+      0.2,
+      0.25,
+      0.3,
+      0.35
+    ],
+    "metadata": {
+      "summary": "Summary for document 1",
+      "topics": [
+        "topic-1",
+        "topic-2"
+      ],
+      "tags": [
+        "test",
+        "fixture"
+      ],
+      "themes": [
+        "demo"
+      ],
+      "priority": 2,
+      "tone": "informational",
+      "stage": "draft",
+      "depth": "surface",
+      "category": "standard"
+    }
+  },
+  "doc_02": {
+    "embedding": [
+      0.2,
+      0.25,
+      0.3,
+      0.35,
+      0.4,
+      0.45
+    ],
+    "metadata": {
+      "summary": "Summary for document 2",
+      "topics": [
+        "topic-2",
+        "topic-0"
+      ],
+      "tags": [
+        "test",
+        "fixture"
+      ],
+      "themes": [
+        "demo"
+      ],
+      "priority": 3,
+      "tone": "informational",
+      "stage": "draft",
+      "depth": "surface",
+      "category": "standard"
+    }
+  },
+  "doc_03": {
+    "embedding": [
+      0.3,
+      0.35,
+      0.4,
+      0.45,
+      0.5,
+      0.55
+    ],
+    "metadata": {
+      "summary": "Summary for document 3",
+      "topics": [
+        "topic-0",
+        "topic-1"
+      ],
+      "tags": [
+        "test",
+        "fixture"
+      ],
+      "themes": [
+        "demo"
+      ],
+      "priority": 4,
+      "tone": "informational",
+      "stage": "draft",
+      "depth": "surface",
+      "category": "standard"
+    }
+  },
+  "doc_04": {
+    "embedding": [
+      0.4,
+      0.45,
+      0.5,
+      0.55,
+      0.6,
+      0.65
+    ],
+    "metadata": {
+      "summary": "Summary for document 4",
+      "topics": [
+        "topic-1",
+        "topic-2"
+      ],
+      "tags": [
+        "test",
+        "fixture"
+      ],
+      "themes": [
+        "demo"
+      ],
+      "priority": 5,
+      "tone": "informational",
+      "stage": "draft",
+      "depth": "surface",
+      "category": "standard"
+    }
+  },
+  "doc_05": {
+    "embedding": [
+      0.5,
+      0.55,
+      0.6,
+      0.65,
+      0.7,
+      0.75
+    ],
+    "metadata": {
+      "summary": "Summary for document 5",
+      "topics": [
+        "topic-2",
+        "topic-0"
+      ],
+      "tags": [
+        "test",
+        "fixture"
+      ],
+      "themes": [
+        "demo"
+      ],
+      "priority": 1,
+      "tone": "informational",
+      "stage": "draft",
+      "depth": "surface",
+      "category": "standard"
+    }
+  },
+  "doc_06": {
+    "embedding": [
+      0.6,
+      0.65,
+      0.7,
+      0.75,
+      0.8,
+      0.85
+    ],
+    "metadata": {
+      "summary": "Summary for document 6",
+      "topics": [
+        "topic-0",
+        "topic-1"
+      ],
+      "tags": [
+        "test",
+        "fixture"
+      ],
+      "themes": [
+        "demo"
+      ],
+      "priority": 2,
+      "tone": "informational",
+      "stage": "draft",
+      "depth": "surface",
+      "category": "standard"
+    }
+  },
+  "doc_07": {
+    "embedding": [
+      0.7,
+      0.75,
+      0.8,
+      0.85,
+      0.9,
+      0.95
+    ],
+    "metadata": {
+      "summary": "Summary for document 7",
+      "topics": [
+        "topic-1",
+        "topic-2"
+      ],
+      "tags": [
+        "test",
+        "fixture"
+      ],
+      "themes": [
+        "demo"
+      ],
+      "priority": 3,
+      "tone": "informational",
+      "stage": "draft",
+      "depth": "surface",
+      "category": "standard"
+    }
+  },
+  "doc_08": {
+    "embedding": [
+      0.8,
+      0.85,
+      0.9,
+      0.95,
+      1.0,
+      1.05
+    ],
+    "metadata": {
+      "summary": "Summary for document 8",
+      "topics": [
+        "topic-2",
+        "topic-0"
+      ],
+      "tags": [
+        "test",
+        "fixture"
+      ],
+      "themes": [
+        "demo"
+      ],
+      "priority": 4,
+      "tone": "informational",
+      "stage": "draft",
+      "depth": "surface",
+      "category": "standard"
+    }
+  },
+  "doc_09": {
+    "embedding": [
+      0.9,
+      0.95,
+      1.0,
+      1.05,
+      1.1,
+      1.15
+    ],
+    "metadata": {
+      "summary": "Summary for document 9",
+      "topics": [
+        "topic-0",
+        "topic-1"
+      ],
+      "tags": [
+        "test",
+        "fixture"
+      ],
+      "themes": [
+        "demo"
+      ],
+      "priority": 5,
+      "tone": "informational",
+      "stage": "draft",
+      "depth": "surface",
+      "category": "standard"
+    }
+  },
+  "doc_10": {
+    "embedding": [
+      1.0,
+      1.05,
+      1.1,
+      1.15,
+      1.2,
+      1.25
+    ],
+    "metadata": {
+      "summary": "Summary for document 10",
+      "topics": [
+        "topic-1",
+        "topic-2"
+      ],
+      "tags": [
+        "test",
+        "fixture"
+      ],
+      "themes": [
+        "demo"
+      ],
+      "priority": 1,
+      "tone": "informational",
+      "stage": "draft",
+      "depth": "surface",
+      "category": "standard"
+    }
+  },
+  "doc_11": {
+    "embedding": [
+      1.1,
+      1.15,
+      1.2,
+      1.25,
+      1.3,
+      1.35
+    ],
+    "metadata": {
+      "summary": "Summary for document 11",
+      "topics": [
+        "topic-2",
+        "topic-0"
+      ],
+      "tags": [
+        "test",
+        "fixture"
+      ],
+      "themes": [
+        "demo"
+      ],
+      "priority": 2,
+      "tone": "informational",
+      "stage": "draft",
+      "depth": "surface",
+      "category": "standard"
+    }
+  }
+}

--- a/tests/test_clustering_from_embeddings.py
+++ b/tests/test_clustering_from_embeddings.py
@@ -1,41 +1,96 @@
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Tuple
+
 import pytest
 
+if "tiktoken" not in sys.modules:
+    try:  # pragma: no cover - exercise real dependency when available
+        import tiktoken  # type: ignore  # noqa: F401
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+        dummy_encoding = types.SimpleNamespace(
+            encode=lambda text, disallowed_special=(): list(text),
+            decode=lambda tokens: "".join(tokens),
+        )
+        sys.modules["tiktoken"] = types.SimpleNamespace(
+            encoding_for_model=lambda model: dummy_encoding
+        )
+
+if "openai" not in sys.modules:
+    class _DummyChat:  # pragma: no cover - optional dependency shim
+        def __init__(self):
+            self.completions = types.SimpleNamespace(
+                create=lambda *a, **k: types.SimpleNamespace(
+                    choices=[
+                        types.SimpleNamespace(
+                            message=types.SimpleNamespace(content="{}")
+                        )
+                    ]
+                )
+            )
+
+    sys.modules["openai"] = types.SimpleNamespace(OpenAI=lambda *a, **k: types.SimpleNamespace(chat=_DummyChat()))
+
+from core.clustering import algorithms
 from core.clustering.clustering_steps import (
     run_clustering,
     run_dimensionality_reduction,
     run_export,
     run_labeling,
 )
-from core.config.config_registry import get_path_config
+from core.config import config_registry
 from core.config.path_config import PathConfig
 from core.logger import get_logger
 from core.workflows.main_commands import classify
 
 logger = get_logger(__name__)
 
-# pytest.skip("Skipping heavy clustering test", allow_module_level=True)
+FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures" / "rich_doc_embeddings.json"
+
+
+def _load_fixture(tmp_path: Path) -> Tuple[Path, Path]:
+    if not FIXTURE_PATH.exists():
+        pytest.skip("rich_doc_embeddings fixture missing")
+
+    with FIXTURE_PATH.open("r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+
+    embedding_path = tmp_path / "rich_doc_embeddings.json"
+    embedding_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    metadata_dir = tmp_path / "metadata"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    for doc_id, record in payload.items():
+        metadata = record.get("metadata", {})
+        (metadata_dir / f"{doc_id}.meta.json").write_text(
+            json.dumps(metadata, indent=2), encoding="utf-8"
+        )
+
+    return embedding_path, metadata_dir
 
 
 def test_clustering_from_embeddings(tmp_path, monkeypatch):
-    logger.info("Testing clustering from existing embeddings...")
-    paths = get_path_config()
-    embedding_path = paths.root / "rich_doc_embeddings.json"
-    metadata_dir = paths.metadata
-    out_dir = paths.output / "test_output"
+    if algorithms.umap is None or algorithms.hdbscan is None:
+        pytest.skip("Clustering dependencies (umap, hdbscan) not available")
 
-    if not embedding_path.exists() or embedding_path.stat().st_size == 0:
-        pytest.skip("embedding file missing")
+    logger.info("Testing clustering from fixture embeddings...")
 
-    logger.info("Using %s for testing.", embedding_path)
-    logger.info("Using %s for testing.", metadata_dir)
-    paths = get_path_config()
-    embedding_path = paths.root / "rich_doc_embeddings.json"
-    metadata_dir = paths.metadata
-    out_dir = paths.output / "test_output"
+    embedding_path, metadata_dir = _load_fixture(tmp_path)
+    out_dir = tmp_path / "cluster_output"
     out_dir.mkdir(parents=True, exist_ok=True)
 
     doc_ids, X, coords = run_dimensionality_reduction(embedding_path)
     labels = run_clustering(X, method="spectral")
+
+    monkeypatch.setattr(
+        "core.clustering.clustering_steps.label_clusters",
+        lambda ids, lbls, md, model="gpt-4": {
+            f"cluster_{int(label)}": f"Label {int(label)}"
+            for label in sorted(set(int(l) for l in lbls if l != -1))
+        },
+    )
     label_map = run_labeling(doc_ids, labels, metadata_dir)
     run_export(doc_ids, coords, labels, label_map, out_dir, metadata_dir)
 
@@ -46,10 +101,9 @@ def test_clustering_from_embeddings(tmp_path, monkeypatch):
     sample_file = pc.parsed / "sample.txt"
     sample_file.write_text("Cats purr. " * 20 + "Dogs bark. " * 20)
 
-    monkeypatch.setattr("core.config.config_registry.get_path_config", lambda: pc)
+    monkeypatch.setattr(config_registry, "get_path_config", lambda: pc)
     monkeypatch.setattr(
-        "core.parsing.semantic_chunk.embed_text",
-        lambda text, model="text-embedding-3-small": [0.0],
+        "core.workflows.main_commands.segment_text", lambda text: [text[:50], text[50:]]
     )
     monkeypatch.setattr(
         "core.workflows.main_commands.summarize_text",
@@ -65,7 +119,7 @@ def test_clustering_from_embeddings(tmp_path, monkeypatch):
             "category": doc_type,
         },
     )
-    metadata = classify(sample_file.name, chunked=True)
+    metadata = classify(sample_file.name, chunked=True, paths=pc)
     assert isinstance(metadata, dict)
     assert pc.metadata.joinpath(f"{sample_file.name}.meta.json").exists()
 
@@ -74,7 +128,7 @@ def test_clustering_from_embeddings(tmp_path, monkeypatch):
     assert out_dir.joinpath("cluster_assignments.csv").exists()
     assert out_dir.joinpath("cluster_summary.csv").exists()
     assert out_dir.joinpath("umap_plot.png").exists()
-    logger.info("Clustering from existing embeddings succeeded.")
+    logger.info("Clustering from fixture embeddings succeeded.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- normalize embedding loading to guarantee 2D arrays and guard clustering reducers for empty/degenerate inputs
- wrap optional umap/hdbscan/tiktoken/faiss imports with runtime errors and provide fixture-driven clustering test data
- refresh clustering test to rely on local fixtures and stub LLM calls instead of external services

## Testing
- pytest tests/test_clustering_from_embeddings.py

------
https://chatgpt.com/codex/tasks/task_e_68d0be40a0d88323ae598f897d6fbe2e