### PR TITLE
Align formatting config and install pytest-mock

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "develop", "feature/**", "bugfix/**", "release/**"]
+  pull_request:
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+          pip install black ruff
+
+      - name: Run Ruff
+        run: ruff check .
+
+      - name: Run tests
+        run: pytest -q
+
+      - name: Check formatting with Black
+        run: black --check .

--- a/intents/2025-10-09__ci_black_alignment.intent.md
+++ b/intents/2025-10-09__ci_black_alignment.intent.md
@@ -1,0 +1,5 @@
+@ai-intent: Capture tradeoff introduced by enabling Black checks in CI
+
+- Added GitHub Actions job that now enforces `black --check .`, but repository currently has multiple files failing formatting.
+- Local run shows 26 files would be reformatted; deferred mass reformat to keep diff scoped to CI plumbing.
+- Follow-up needed: schedule formatting sprint or selectively update modules before merging CI enforcement into default branch.

--- a/purpose_files/github.workflows.ci.purpose.md
+++ b/purpose_files/github.workflows.ci.purpose.md
@@ -1,0 +1,46 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+
+# Module: github.workflows.ci
+
+# @ai-path: github.workflows.ci
+# @ai-source-file: .github/workflows/ci.yaml
+# @ai-role: devops-pipeline
+# @ai-intent: "Enforce linting, testing, and formatting gates through GitHub Actions."
+
+### 🎯 Intent & Responsibility
+- Execute repository quality gates (`ruff`, `pytest`, `black --check`) on pushes and pull requests across mainline and feature branches.
+- Provide automated feedback to maintainers before merge, reinforcing local dev parity with CI.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name                    | Type                                        | Brief Description |
+|-----------|-------------------------|---------------------------------------------|-------------------|
+| 📥 In     | repository snapshot     | git checkout (HEAD commit)                  | Source files fetched via `actions/checkout@v4`. |
+| 📥 In     | python-version          | str (semver)                                | Runtime selected by `actions/setup-python@v5` (3.11). |
+| 📥 In     | workflow triggers       | GitHub event payload (`push`/`pull_request`) | Covers `main`, `develop`, and `feature/**`, `bugfix/**`, `release/**` branches to gate work-in-progress refs. |
+| 📤 Out    | quality status          | Literal["success", "failure"]              | Aggregated job result surfaced as GitHub Check. |
+| 📤 Out    | step annotations        | List[GitHubActionAnnotation]                | Inline diagnostics from `ruff`, `pytest`, or `black`. |
+
+### 🔄 Coordination Mechanics
+- Single `quality` job runs sequential steps; failure in any gate short-circuits subsequent checks.
+- Uses GitHub Actions log/annotation channel for feedback, aligning with @ai-cadence: run for rapid regression signals.
+- Shared pip cache is implicit via default Actions runner; no custom caching introduced.
+
+### 🔗 Dependencies
+- `actions/checkout@v4` for code retrieval.
+- `actions/setup-python@v5` to provision Python 3.11 runtime.
+- PyPI packages installed via `pip install -r requirements.txt`, editable install `pip install -e .`, and targeted tools (`black`, `ruff`). The requirements set now includes `pytest-mock` to supply the `mocker` fixture expected by the pytest suite.
+
+### ⚠️ Integration Risks
+- Installing heavy optional deps (e.g., `faiss-cpu`, `PyMuPDF`) may increase runtime; monitor for timeouts.
+- Workflow assumes tests do not require external secrets; any future secret usage must leverage GitHub encrypted secrets.
+
+### 🧩 Ecosystem Anchoring
+- Governs quality gates for modules documented under `purpose_files/`, ensuring synchronization with memory architecture.
+- Supports maintainers (`architect`, `executor`, `memory_architect`) by providing automatic regress detection before merge.
+- Downstream: PR reviewers rely on the `quality` job status to approve merges; failure should trigger `.intent.md` updates for remediation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,16 @@ kairos = "cli.main:app"
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
 [tool.setuptools]
 package-dir = {"" = "src"}
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]
 
 [tool.isort]
 profile = "black"

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ tqdm
 
 # Optional: Dev/Testing
 pytest
+pytest-mock
 python-dotenv  # if you want to externalize secrets later
 
 # Pin versions for stability (optional but recommended for production)


### PR DESCRIPTION
## Summary
- broaden the CI workflow triggers to cover main, develop, and feature, bugfix, release branches alongside pull requests
- ensure the workflow installs requirements first and then the package in editable mode for reliable dependency resolution
- document the expanded trigger set and editable install expectations in the CI purpose file
- configure Ruff and Black to share the same formatting targets so the linters agree on style
- add pytest-mock to the requirements bundle so the pytest `mocker` fixture is always available in CI

## Testing
- ruff check .
- pytest -q
- black --check . *(fails: repository retains existing formatting drift in 26 files)*

------
https://chatgpt.com/codex/tasks/task_e_68d16cd194948323b9b6514e51baffd9