### PR TITLE
Refactor pipeline helpers

### DIFF
--- a/demo_script.py
+++ b/demo_script.py
@@ -9,7 +9,7 @@ from src.core.clustering.clustering_steps import (
     run_labeling,
 )
 from src.core.config.config_registry import get_path_config
-from src.scripts.pipeline import run_full_pipeline
+from src.scripts.pipeline import run_pipeline
 
 pytest.skip("Demo script not meant for pytest", allow_module_level=True)
 
@@ -23,7 +23,7 @@ pytest.skip("Demo script not meant for pytest", allow_module_level=True)
 
 
 def run_demo():
-    run_full_pipeline(
+    run_pipeline(
         Path("./incoming_docs"),
         chunked=True,
         method="summary",

--- a/purpose_files/cli.pipeline.purpose.md
+++ b/purpose_files/cli.pipeline.purpose.md
@@ -31,7 +31,7 @@
 | 📤 Out | cluster_output | Folder | CSV/PNG cluster exports |
 
 ### 🔗 Dependencies
-- `scripts.pipeline.run_full_pipeline`
+- `scripts.pipeline.run_pipeline`
 - `core.clustering.clustering_steps.run_all_steps`
 - `core.config.config_registry.get_path_config`
 

--- a/purpose_files/scripts.pipeline.purpose.md
+++ b/purpose_files/scripts.pipeline.purpose.md
@@ -5,6 +5,7 @@
 - Serve as a one-stop execution layer for the full LLM-powered pipeline.
 - Ingest files from a local folder, route them through upload + parsing → classification → embedding stages.
 - Handle optional chunked summarization and overwrite behavior for idempotent operation.
+- Expose `upload_file`, `classify_document`, and `embed_document` helpers that encapsulate each stage for reuse and testing.
 
 ### 📥 Inputs & 📤 Outputs
 | Direction | Name         | Type     | Brief Description                                                               |

--- a/src/cli/pipeline.py
+++ b/src/cli/pipeline.py
@@ -6,7 +6,7 @@ import typer
 from core.clustering.clustering_steps import run_all_steps
 from core.config.config_registry import get_path_config
 from core.config.path_config import PathConfig
-from scripts.pipeline import run_full_pipeline
+from scripts.pipeline import run_pipeline
 
 app = typer.Typer()
 
@@ -55,7 +55,7 @@ def run_all(
     paths = _resolve_paths(root, raw_dir, parsed_dir, metadata_dir, output_dir)
 
     # Steps 1–3
-    run_full_pipeline(
+    run_pipeline(
         input_dir=input_dir,
         chunked=chunked,
         method=method,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -142,7 +142,7 @@ def test_run_pipeline_happy_path(sample_paths: PathConfig) -> None:
         patch.object(pipeline, "classify") as classify_mock,
         patch.object(pipeline, "generate_embeddings") as embed_mock,
     ):
-        pipeline.run_full_pipeline(
+        pipeline.run_pipeline(
             input_dir=sample_paths.raw,
             chunked=False,
             overwrite=True,


### PR DESCRIPTION
## Summary
- refactor the scripts pipeline module into upload, classify, and embed helpers and expose a run_pipeline wrapper
- update CLI, demo, tests, and purpose docs to reference the new run_pipeline entrypoint

## Testing
- pytest tests/test_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d2a1709bd88323864d0bf00fd30d71