### PR TITLE
Refactor lambda summary config handling

### DIFF
--- a/intents/2025-09-21__lambda_summary_config.intent.md
+++ b/intents/2025-09-21__lambda_summary_config.intent.md
@@ -1,0 +1,6 @@
+@ai-intent: inject-remote-config-into-lambda-summary
+- Lambda wrapper now requires a caller-supplied RemoteConfig so orchestration layers control region/bucket selection without implicit file reads.
+- Cached Lambda clients by region string to keep performance parity while avoiding unhashable RemoteConfig caching issues.
+- Updated module purpose contract to document the config dependency and client caching expectations.
+@ai-risk-io: update-callers
+- Any remaining code paths must be updated to pass RemoteConfig explicitly; otherwise invocations will fail fast when signatures diverge.

--- a/purpose_files/core.utils.lambda_summary.purpose.md
+++ b/purpose_files/core.utils.lambda_summary.purpose.md
@@ -7,17 +7,18 @@
 - Parse, retry, and safely decode potentially malformed Lambda responses.
 
 ### 📥 Inputs & 📤 Outputs
-| Direction | Name             | Type         | Brief Description                                                                 |
-|-----------|------------------|--------------|------------------------------------------------------------------------------------|
-| 📥 In     | s3_filename       | str          | S3 key or filename of parsed text in cloud storage                                |
-| 📥 In     | override_text     | Optional[str]| Raw text to substitute instead of pulling from S3                                 |
-| 📤 Out    | raw_response      | str          | Claude-generated JSON string returned by Lambda                                   |
-| 📤 Out    | unpacked_metadata | dict         | Parsed and structured metadata result (summary, tags, tone, etc.)                 |
+| Direction | Name             | Type                     | Brief Description |
+|-----------|------------------|--------------------------|-------------------------------------------------------------------------------------|
+| 📥 In     | config           | RemoteConfig             | AWS + storage configuration injected by caller |
+| 📥 In     | s3_filename      | str                      | S3 key or filename of parsed text in cloud storage |
+| 📥 In     | override_text    | Optional[str]            | Raw text to substitute instead of pulling from S3 |
+| 📤 Out    | raw_response     | str                      | Claude-generated JSON string returned by Lambda |
+| 📤 Out    | unpacked_metadata| dict                     | Parsed and structured metadata result (summary, tags, tone, etc.) |
 
 ### 🔗 Dependencies
 - `boto3`, `json`, `time`, `random`
 - `core.storage.aws_clients.get_lambda_client`, `get_s3_client`
-- `core.config.remote_config.RemoteConfig`
+- `core.configuration.remote_config.RemoteConfig`
 
 ### ⚙️ AI-Memory Tags
 - `@ai-assumes:` AWS Lambda function is deployed correctly and can accept the provided payload structure.
@@ -28,4 +29,5 @@
 - This system enables LLM-powered summaries without incurring local inference costs.
 - Claude-specific prompting logic is embedded in `invoke_chatlog_summary`, while `invoke_summary` is general-purpose.
 - `unpack_lambda_claude_result` anticipates nested or malformed payloads and attempts safe recovery.
+- Lambda and S3 clients are cached per AWS region; callers must pass their own `RemoteConfig` to avoid hidden global state.
 - Useful for cost-splitting summarization workflows across local/cloud compute.


### PR DESCRIPTION
## Summary
- require a caller-supplied `RemoteConfig` when invoking the AWS Lambda summarization helpers and drop the implicit file lookup
- cache Lambda clients by region while improving retry logging and error handling
- document the new config dependency in the module purpose file and capture the design intent in repository memory

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2ccbad13c83238603b5853e93c0a7