### PR TITLE
Optimize embedding batch calls

### DIFF
--- a/intents/2025-10-16__embedding_batch_performance.intent.md
+++ b/intents/2025-10-16__embedding_batch_performance.intent.md
@@ -1,0 +1,5 @@
+@ai-intent: Accelerate embedding pipeline without breaking semantic chunk fidelity
+
+- Added cached OpenAI client + encoding reuse in `core.embeddings.embedder` so repeated chunk calls stop reinitializing HTTP sessions.
+- Introduced `embed_text_batch` and refactored `semantic_chunk` to batch both window + segment embeddings, eliminating the tight loop of single-request OpenAI calls.
+- Budget tracker now charges batched requests once per payload, keeping spend checks aligned with new aggregation behavior.

--- a/purpose_files/core.parsing.semantic_chunk.purpose.md
+++ b/purpose_files/core.parsing.semantic_chunk.purpose.md
@@ -15,9 +15,9 @@
 
 ### 🎯 Intent & Responsibility
 - Slide 256-token windows over the text with stride 128.
-- Embed each window using `text-embedding-3-large`.
+- Batch window texts through `embed_text_batch` to keep OpenAI calls bounded.
 - Reduce dimensions with UMAP and cluster via Spectral Clustering (HDBSCAN fallback).
-- Merge adjacent windows with identical cluster IDs into final chunks.
+- Merge adjacent windows with identical cluster IDs into final chunks and embed those chunks in batches.
 
 ### 📥 Inputs & 📤 Outputs
 | Direction | Name | Type | Brief Description |
@@ -31,10 +31,12 @@
 ### 🔗 Dependencies
 - `tiktoken` for tokenization
 - `umap-learn`, `sklearn.cluster.SpectralClustering`, `hdbscan`
-- `core.embeddings.embedder.embed_text`
+- `core.embeddings.embedder.embed_text` and `embed_text_batch`
 
 ### 🗣 Dialogic Notes
 - Works best when text length >> window size, giving enough context for clustering.
+- Window embeddings are now generated in batches, preventing the embedding agent from looping on hundreds of single-text calls.
+- Final chunk embeddings reuse the same batching helper to stay within the budget guardrails.
 - Future improvements might use HDBSCAN or heuristics to auto-select cluster count.
 
 ### 9 Pipeline Integration


### PR DESCRIPTION
## Summary
- cache the OpenAI client/encoding and add `embed_text_batch` so short texts are embedded in a single request with budget tracking
- refactor semantic chunking to batch window and segment embeddings while preserving monkeypatch hooks
- document the batching behavior in the embedder and semantic chunk purpose files and capture the intent update

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d35821e7648323bfce24744fc8b4af