### PR TITLE
Finalize Trace A schema config consolidation

### DIFF
--- a/Codex_++/intents/2025-01-24__trace_a_schema_config.intent.md
+++ b/Codex_++/intents/2025-01-24__trace_a_schema_config.intent.md
@@ -1,0 +1,18 @@
+@ai-intent: Capture Trace A schema-config consolidation decisions
+@ai-role: memory_architect
+@ai-cadence: drift
+@ai-risk-architecture: medium (config drift touches every pipeline)
+
+## Context
+- Completed audit of modules consuming `get_path_config` / `configure`; migrated imports to `core.configuration.*` and removed inline schema literals.
+- Introduced `validate_schema_path` to centralize fallback behavior and ensure warnings surface once per process.
+- DEFAULT_METADATA_SCHEMA_PATH now resolves to an absolute `Path` via `.resolve(strict=False)` to avoid surprises in air-gapped runs.
+
+## Trade-offs & Rationale
+- Opted for sentinel-based override reset in `config_registry.configure` to support `configure(path_config_path=None)` semantics without breaking legacy callers.
+- Added CLI regression harness using Typer runner to prove cached schema reuse without invoking the heavy pipeline; keeps tests fast while covering integration cadence.
+- Document drift guard rails implemented via `tests/test_doc_drift.py`; scope limited to refreshed modules to avoid destabilizing legacy docs.
+
+## Follow-ups
+- Consider regenerating `ast_deps.csv` after major refactors so drift guard remains trustworthy at larger scale.
+- Evaluate extracting a shared CLI bootstrap helper (per prior intent) once other pipelines adopt Trace A config contract.

--- a/Codex_++/purpose_files/core.configuration.config_registry.purpose.md
+++ b/Codex_++/purpose_files/core.configuration.config_registry.purpose.md
@@ -1,0 +1,50 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: core.configuration.config_registry
+- @ai-source-file: config_registry.py
+- @ai-role: config_registry
+- @ai-intent: "Cache and expose path + remote configuration objects with safe overrides."
+- @ai-version: 0.4.0
+- @ai-generated: true
+- @human-reviewed: false
+- @schema-version: 0.3
+- @ai-risk-pii: none
+- @ai-risk-performance: "Negligible — lazily loads JSON once per process."
+- @ai-dependencies: core.configuration.path_config, core.configuration.remote_config, pathlib
+- @ai-used-by: core.config, cli.*, scripts.pipeline, core.embeddings.embedder, core.retrieval.retriever
+- @ai-downstream: core.metadata.schema, gui.chat_gui, core.workflows.main_commands
+
+## Module Summary
+The registry centralizes configuration loading and caching. It tracks the current JSON file locations, allows overrides via `configure`, and exposes singleton instances for `PathConfig` and `RemoteConfig`. Trace A consolidation introduced default-path reset semantics and ensures `.resolve(strict=False)` is applied to all overrides.
+
+### IO Contracts
+| Channel | Name | Type | Description |
+| --- | --- | --- | --- |
+| 📥 In | path_config_path | Path \| str \| None | Optional override for path config file; `None` resets to default JSON. |
+| 📥 In | remote_config_path | Path \| str \| None | Optional override for remote config file; `None` resets to default JSON. |
+| 📤 Out | PathConfig | PathConfig | Cached filesystem configuration (schema, directories, feature flags). |
+| 📤 Out | RemoteConfig | RemoteConfig | Cached remote settings (API keys, S3 prefixes). |
+
+### Schema Resolution
+- Delegates to `PathConfig.from_file` which leverages `validate_schema_path` for default schema fallback.
+- Maintains `_DEFAULT_*` path constants resolved with `.expanduser().resolve(strict=False)` to avoid brittle relative paths.
+- Resetting overrides with `configure(path_config_path=None)` clears the cached object and rehydrates from defaults, ensuring deterministic schema usage across repeated calls.
+
+### Coordination Mechanics
+- Acts as the configuration nexus for CLI commands, pipelines, and long-lived services via module-level singletons.
+- Works with `core.config` shim to maintain backwards compatibility while pointing to Trace A modules.
+- Relies on `pathlib.Path` for normalization and is safe to invoke from multi-threaded contexts thanks to simple module-level caching.
+
+### Integration Notes
+- Accessed by embedding, retrieval, metadata validation, storage, and GUI modules for consistent configuration state.
+- Tests patch `get_path_config` to inject temporary directories; the new reset semantics keep caches deterministic between tests.
+- CLI guardrails now depend on this registry rather than embedding schema literals.
+
+### Risks & Mitigations
+- **Stale caches:** `force_reload=True` path ensures updates propagate; `configure(None)` clears overrides explicitly.
+- **Invalid overrides:** `.resolve(strict=False)` combined with try/except fallback yields default configs when files are missing.

--- a/Codex_++/purpose_files/core.configuration.path_config.purpose.md
+++ b/Codex_++/purpose_files/core.configuration.path_config.purpose.md
@@ -1,0 +1,53 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: core.configuration.path_config
+- @ai-source-file: path_config.py
+- @ai-role: config_paths
+- @ai-intent: "Resolve ingestion directories and metadata schema locations for all pipelines."
+- @ai-version: 0.4.0
+- @ai-generated: true
+- @human-reviewed: false
+- @schema-version: 0.3
+- @ai-risk-pii: none
+- @ai-risk-performance: "Negligible — pure path arithmetic."
+- @ai-dependencies: core.constants.ERROR_PATH_RESOLVE_FAILURE, json, pathlib
+- @ai-used-by: core.configuration.config_registry, cli.pipeline, scripts.pipeline, core.embeddings.embedder, core.retrieval.retriever
+- @ai-downstream: core.metadata.schema, core.storage.upload_local
+
+## Module Summary
+`PathConfig` encapsulates all filesystem roots required by the Trace A ingestion stack. It normalizes user overrides relative to a project root, validates the metadata schema path, and exposes convenience constructors for JSON configuration. The companion helper `validate_schema_path` guards against missing schema files while preserving reproducible defaults.
+
+### IO Contracts
+| Channel | Name | Type | Description |
+| --- | --- | --- | --- |
+| 📥 In | root | Path \| str \| None | Base directory used for relative path expansion. |
+| 📥 In | raw/parsed/metadata/output/vector | Path \| str \| None | Optional overrides for specific storage folders. |
+| 📥 In | schema | Path \| str \| None | Optional schema override validated via `validate_schema_path`. |
+| 📥 In | semantic_chunking | bool | Feature flag toggling semantic chunk segmentation. |
+| 📤 Out | PathConfig.root | Path | Absolute root directory. |
+| 📤 Out | PathConfig.schema | Path | Resolved metadata schema path (always absolute + validated). |
+| 📤 Out | PathConfig.vector | Path | Vector index + chunk artifact directory. |
+
+### Schema Resolution
+- Defaults to `core.constants.DEFAULT_METADATA_SCHEMA_PATH`, resolved with `Path.resolve(strict=False)`.
+- `validate_schema_path` checks overrides, logs a warning when files are missing, and falls back to the default schema while keeping the cache warm.
+- JSON deserialization via `PathConfig.from_file` now omits inline schema literals, aligning with Trace A consolidation.
+
+### Coordination Mechanics
+- Central feed into `core.configuration.config_registry`, ensuring CLI, workflows, and services consume the same cached instance.
+- Logging via `core.logger` (transitively) documents fallback behavior for observability.
+- Propagates semantic chunking flag to embedding + classification pipelines.
+
+### Integration Notes
+- Consumed during CLI path resolution (`cli.pipeline._resolve_paths`) and ingestion pipelines (`scripts.pipeline.run_pipeline`).
+- Referenced by metadata validation (`core.metadata.schema.validate_metadata`) and storage helpers (`core.storage.upload_local`).
+- Maintains compatibility with environment overrides defined in `core.config` while removing hard-coded schema paths.
+
+### Risks & Mitigations
+- **User typos:** `_resolve_path_relative_to_root` raises descriptive errors using `ERROR_PATH_RESOLVE_FAILURE`.
+- **Missing schema files:** `validate_schema_path` logs a warning and reverts to the known-good default, preventing runtime crashes.

--- a/Codex_++/purpose_files/core.retrieval.retriever.purpose.md
+++ b/Codex_++/purpose_files/core.retrieval.retriever.purpose.md
@@ -1,53 +1,54 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
 - @ai-path: core.retrieval.retriever
 - @ai-source-file: retriever.py
-- @ai-role: logic
-- @ai-intent: "Embed one or more queries, rank results, and optionally aggregate chunk text across documents."
-- @ai-version: 0.2.0
+- @ai-role: retriever
+- @ai-intent: "Rank vector-store hits for one or more natural-language queries."
+- @ai-version: 0.3.0
 - @ai-generated: true
-- @ai-verified: false
 - @human-reviewed: false
-- @schema-version: 0.2
+- @schema-version: 0.3
 - @ai-risk-pii: low
-- @ai-risk-performance: "Embedding model calls incur latency and cost."
+- @ai-risk-performance: "Embedding + FAISS search bounded by query batch size."
+- @ai-dependencies: core.configuration.config_registry, core.embeddings.embedder, core.logger.get_logger, core.vectorstore.faiss_store, json, numpy, pathlib
+- @ai-used-by: core.workflows.main_commands, cli.pipeline, scripts.pipeline
+- @ai-downstream: core.synthesis.summarizer, gui.chat_gui
 
-# Module: core.retrieval.retriever
-> Unified interface for semantic search against the FAISS vector store.
+## Module Summary
+Retriever centralizes semantic search against the FAISS index. It resolves storage locations via the shared `PathConfig` cache, infers embedding dimensions, and exposes helpers for single query, multi-query, and file-based retrieval. Result aggregation can collapse chunk-level hits back to document-level summaries for downstream synthesis loops.
 
-### 🎯 Intent & Responsibility
-- Convert query text to embeddings using the configured model.
- - Delegate search to `FaissStore` and return ranked document filenames using `id_map.json`.
-- Provide an easy-to-mock layer for CLI and future agent use.
-- Detect index dimension at init and switch embedding model accordingly.
+### IO Contracts
+| Channel | Name | Type | Description |
+| --- | --- | --- | --- |
+| 📥 In | store | FaissStore \| None | Optional pre-built index; defaults to vector path from `PathConfig`. |
+| 📥 In | model | str \| None | Embedding model override; auto-inferred from FAISS index dimension when omitted. |
+| 📥 In | chunk_dir | Path \| None | Directory containing cached chunk text; defaults to `<vector>/chunks` when present. |
+| 📥 In | texts | Iterable[str] | Query strings handled by `query_multi`. |
+| 📤 Out | ranked | List[Tuple[str, float]] | Ranked `(doc_id, score)` pairs for top-k hits. |
+| 📤 Out | enriched | List[Tuple[str, float, str]] | Ranked triples including chunk text when `return_text=True`. |
 
-### 📥 Inputs & 📤 Outputs
-| Direction | Name | Type | Brief Description |
-|-----------|------|------|-------------------|
-| 📥 In | text | str | Search query text (via ``query``) |
-| 📥 In | texts | Iterable[str] | Multiple search queries (``query_multi``) |
-| 📥 In | file | Path | Text file used as query (``query_file``) |
-| 📥 In | k | int | Number of results to return |
-| 📥 In | chunk_dir | Path (optional) | Directory holding text chunks for retrieval |
-| 📥 In | return_text | bool (optional) | Include chunk text when `chunk_dir` is configured |
-| 📥 In | aggregate | bool (optional) | Combine chunks by document when using ``query_multi`` |
-| 📤 Out | results | List[Tuple[str, float]] or List[Tuple[str, float, str]] | Ranked IDs and scores, optionally aggregated with text |
+### Schema Resolution
+- Delegates filesystem discovery to `core.configuration.config_registry.get_path_config`.
+- `PathConfig` internally calls `validate_schema_path`, ensuring cached schema paths stay reproducible even when overrides are missing.
+- Vector index (`mosaic.index`), `id_map.json`, and optional chunk cache resolve under `paths.vector`.
 
-### 🔗 Dependencies
-- `core.embeddings.embedder.embed_text`
-- `core.vectorstore.faiss_store.FaissStore`
-- `numpy`
-- `core.utils.logger`
+### Coordination Mechanics
+- Embedding provider: `core.embeddings.embedder` (uses same registry + schema contract).
+- Vector store: `core.vectorstore.faiss_store.FaissStore` handles search, exposes `index.d` for dimension inference.
+- Logging: `core.logger.get_logger` surfaces cadence + model auto-detection to observability feeds.
+- Aggregation: merges multi-query hits, supports chunk aggregation for the Synthesizer agent.
 
-### 🗣 Dialogic Notes
-- Embedding model is configurable; defaults to OpenAI `text-embedding-3-small`.
-- Agents will call this layer instead of accessing FAISS directly.
-- When no model is specified, the retriever infers one by reading the FAISS index dimension.
-- Uses `id_map.json` to translate FAISS integer IDs back to document filenames.
-- When embeddings include chunk IDs (`doc_chunk01`), results may refer to those composite identifiers and `return_text` can load the chunk file if available.
-- `query_multi` merges scores across queries and can group chunks by their document prefix when `aggregate=True`.
-- `query_file` reads text from disk then delegates to `query`.
+### Integration Notes
+- Upstream call sites: CLI (`cli.pipeline.run_all`), scripted ingestion (`scripts.pipeline.run_pipeline`), and workflow orchestrators (`core.workflows.main_commands`).
+- Downstream: Summarization (`core.synthesis.summarizer`) and GUI retrieval experiences consume ranked outputs.
+- Maintains compatibility with Trace A schema consolidation by never embedding schema literals; all configuration flows through cached registries.
 
-### 9 Pipeline Integration
-- @ai-pipeline-order: inverse
-- **Coordination Mechanics:** Receives query embeddings from `embed_text` and consults `FaissStore`; can merge scores across multiple queries and aggregate retrieved chunk text.
-- **Integration Points:** Results feed directly into the Synthesizer RAG loop and TokenMap Analyzer for token-level context alignment.
-- **Risks:** Retrieval across many chunks may load large text blobs and increase latency; misaligned embeddings reduce search quality.
+### Risks & Mitigations
+- **Index drift:** Embedding model mismatch mitigated by dimension auto-detection and logging.
+- **Missing chunk text:** Gracefully returns empty strings when chunk files absent; aggregation still returns ranking.
+- **Config drift:** Reliance on `PathConfig` ensures shared schema + vector roots even across CLI/worker contexts.

--- a/ast_deps.csv
+++ b/ast_deps.csv
@@ -5,7 +5,7 @@ cli\agent.run,cli\agent.r.strip
 cli\agent.run,cli\agent.roles.split
 cli\agent.run,cli\agent.r.strip
 cli\batch_ops.classify_all,cli\batch_ops.app.command
-cli\batch_ops.classify_all,core.config.config_registry.get_path_config
+cli\batch_ops.classify_all,core.configuration.config_registry.get_path_config
 cli\batch_ops.classify_all,cli\batch_ops.sorted
 cli\batch_ops.classify_all,cli\batch_ops.paths.parsed.glob
 cli\batch_ops.classify_all,cli\batch_ops.meta_path.exists
@@ -44,12 +44,12 @@ cli\cluster.run_all,cli\cluster.app.command
 cli\cluster.run_all,typer.Option
 cli\cluster.run_all,typer.Option
 cli\cluster.run_all,typer.Option
-cli\cluster.run_all,core.config.config_registry.get_path_config
+cli\cluster.run_all,core.configuration.config_registry.get_path_config
 cli\cluster.run_all,core.clustering.clustering_steps.run_all_steps
 cli\dedup.dedup_prompts,cli\dedup.app.command
 cli\dedup.dedup_prompts,typer.Option
 cli\dedup.dedup_prompts,typer.Option
-cli\dedup.dedup_prompts,core.config.config_registry.get_path_config
+cli\dedup.dedup_prompts,core.configuration.config_registry.get_path_config
 cli\dedup.dedup_prompts,core.utils.dedup.dedup_lines_in_folder
 cli\dedup.dedup_prompts,typer.echo
 cli\dedup.dedup_prompts,pathlib.Path
@@ -57,10 +57,10 @@ cli\dedup.dedup_prompts,pathlib.Path
 cli\embed.all,cli\embed.app.command
 cli\embed.all,typer.Option
 cli\embed.all,typer.Option
-cli\embed.all,core.config.config_registry.get_path_config
+cli\embed.all,core.configuration.config_registry.get_path_config
 cli\embed.all,core.embeddings.embedder.generate_embeddings
 cli\export.parse,cli\export.app.command
-cli\export.parse,core.config.config_registry.get_path_config
+cli\export.parse,core.configuration.config_registry.get_path_config
 cli\export.parse,core.parsing.parse_chatgpt_export
 cli\organize.organize_file,core.metadata.io.load_metadata
 cli\organize.organize_file,pathlib.Path.stem.lower
@@ -86,8 +86,8 @@ cli\organize.organize_file,cli\organize.source_src.replace
 cli\organize.organize_file,cli\organize.logger.info
 cli\organize.organize_file,cli\organize.logger.warning
 cli\organize.organize_file,pathlib.Path
-cli\parse._resolve_paths,core.config.config_registry.get_path_config
-cli\parse._resolve_paths,core.config.path_config.PathConfig
+cli\parse._resolve_paths,core.configuration.config_registry.get_path_config
+cli\parse._resolve_paths,core.configuration.path_config.PathConfig
 cli\parse.run,cli\parse.app.command
 cli\parse.run,typer.Argument
 cli\parse.run,typer.Option
@@ -101,8 +101,8 @@ cli\parse.run,cli\parse.sorted
 cli\parse.run,core.storage.upload_local.prepare_document_for_processing
 cli\parse.run,cli\parse.input_path.glob
 cli\parse.run,core.storage.upload_local.prepare_document_for_processing
-cli\pipeline._resolve_paths,core.config.config_registry.get_path_config
-cli\pipeline._resolve_paths,core.config.path_config.PathConfig
+cli\pipeline._resolve_paths,core.configuration.config_registry.get_path_config
+cli\pipeline._resolve_paths,core.configuration.path_config.PathConfig
 cli\pipeline.run_all,cli\pipeline.app.command
 cli\pipeline.run_all,typer.Option
 cli\pipeline.run_all,typer.Option
@@ -347,7 +347,7 @@ core\clustering\export.export_cluster_data,core\clustering\export.meta.get
 core\clustering\export.export_cluster_data,core\clustering\export.meta.get
 core\clustering\export.export_cluster_data,core\clustering\export.meta.get
 core\clustering\labeling.label_clusters,core\clustering\labeling.zip
-core\clustering\labeling.label_clusters,core.config.config_registry.get_remote_config
+core\clustering\labeling.label_clusters,core.configuration.config_registry.get_remote_config
 core\clustering\labeling.label_clusters,openai.OpenAI
 core\clustering\labeling.label_clusters,core\clustering\labeling.cluster_map.items
 core\clustering\labeling.label_clusters,core\clustering\labeling.cluster_map.setdefault.append
@@ -457,7 +457,7 @@ core\configuration\remote_config.from_file,pathlib.Path.expanduser
 core\configuration\remote_config.from_file,core.constants.ERROR_REMOTE_CONFIG_MISSING_FIELDS.format
 core\configuration\remote_config.from_file,pathlib.Path
 core\embeddings\embedder.get_model_for_dim,core\embeddings\embedder.MODEL_BY_DIM.get
-core\embeddings\embedder.embed_text,core.config.config_registry.get_remote_config
+core\embeddings\embedder.embed_text,core.configuration.config_registry.get_remote_config
 core\embeddings\embedder.embed_text,openai.OpenAI
 core\embeddings\embedder.embed_text,core.utils.budget_tracker.get_budget_tracker
 core\embeddings\embedder.embed_text,tiktoken.encoding_for_model
@@ -481,7 +481,7 @@ core\embeddings\embedder.embed_text,core\embeddings\embedder.RuntimeError
 core\embeddings\embedder.embed_text,core\embeddings\embedder.len
 core\embeddings\embedder.embed_text,core\embeddings\embedder.len
 core\embeddings\embedder.generate_embeddings,pathlib.Path
-core\embeddings\embedder.generate_embeddings,core.config.config_registry.get_path_config
+core\embeddings\embedder.generate_embeddings,core.configuration.config_registry.get_path_config
 core\embeddings\embedder.generate_embeddings,core\embeddings\embedder.MODEL_DIMS.get
 core\embeddings\embedder.generate_embeddings,core\embeddings\embedder.index_path.exists
 core\embeddings\embedder.generate_embeddings,core.vectorstore.faiss_store.FaissStore
@@ -556,9 +556,9 @@ core\llm\invoke.run_openai_completion,core\llm\invoke.tracker.check
 core\llm\invoke.run_openai_completion,core\llm\invoke.RuntimeError
 core\llm\invoke.run_openai_completion,core\llm\invoke.LLM_PROMPT_COST_PER_1K.get
 core\llm\invoke.run_openai_completion,core\llm\invoke.LLM_COMPLETION_COST_PER_1K.get
-core\llm\invoke.run_openai_completion,core.config.remote_config.RemoteConfig.from_file
+core\llm\invoke.run_openai_completion,core.configuration.remote_config.RemoteConfig.from_file
 core\llm\invoke.summarize_text,core\llm\invoke.run_openai_completion
-core\llm\invoke.summarize_text,core.config.remote_config.RemoteConfig.from_file
+core\llm\invoke.summarize_text,core.configuration.remote_config.RemoteConfig.from_file
 core\llm\invoke.summarize_text,core\llm\invoke.prompt_override.format
 core\llm\invoke.summarize_text,core\llm\invoke.load_prompt
 core\llm\invoke.summarize_text,core\llm\invoke.base_prompt.format
@@ -572,7 +572,7 @@ core\llm\invoke.test_summarize_text_standard,core\llm\invoke.result.get
 core\llm\invoke.test_summarize_text_chatlog,core\llm\invoke.summarize_text
 core\llm\invoke.test_summarize_text_chatlog,core\llm\invoke.isinstance
 core\llm\invoke.test_summarize_text_chatlog,core\llm\invoke.result.get
-core\memory\frame_store.__init__,core.config.config_registry.get_path_config
+core\memory\frame_store.__init__,core.configuration.config_registry.get_path_config
 core\memory\frame_store.__init__,core\memory\frame_store.self.path.mkdir
 core\memory\frame_store.save_frame,core\memory\frame_store.fpath.write_text
 core\memory\frame_store.save_frame,json.dumps
@@ -665,7 +665,7 @@ core\metadata\merge.flatten,core\metadata\merge.block.get
 core\metadata\merge.most_common,collections.Counter.most_common
 core\metadata\merge.most_common,collections.Counter
 core\metadata\merge.most_common,core\metadata\merge.block.get
-core\metadata\schema.validate_metadata,core.config.config_registry.get_path_config
+core\metadata\schema.validate_metadata,core.configuration.config_registry.get_path_config
 core\metadata\schema.validate_metadata,pathlib.Path
 core\metadata\schema.validate_metadata,core\metadata\schema.logger.info
 core\metadata\schema.validate_metadata,jsonschema.validate
@@ -857,7 +857,7 @@ core\parsing\__init__.segment_topics,openai_export.parse_chatgpt_export
 core\parsing\__init__.topic_segmenter,openai_export.parse_chatgpt_export
 core\parsing\__init__.parse_chatgpt_export,openai_export.parse_chatgpt_export
 core\retrieval\retriever.__init__,core.logger.get_logger
-core\retrieval\retriever.__init__,core.config.config_registry.get_path_config
+core\retrieval\retriever.__init__,core.configuration.config_registry.get_path_config
 core\retrieval\retriever.__init__,core.embeddings.embedder.MODEL_DIMS.get
 core\retrieval\retriever.__init__,core\retrieval\retriever.id_map_path.exists
 core\retrieval\retriever.__init__,core.vectorstore.faiss_store.FaissStore
@@ -944,7 +944,7 @@ core\storage\upload_local.prepare_document_for_processing,core\storage\upload_lo
 core\storage\upload_local.prepare_document_for_processing,core\storage\upload_local.stub_file.write_text
 core\storage\upload_local.prepare_document_for_processing,core\storage\upload_local.logger.info
 core\storage\upload_local.prepare_document_for_processing,core\storage\upload_local.logger.info
-core\storage\upload_local.prepare_document_for_processing,core.config.config_registry.get_path_config
+core\storage\upload_local.prepare_document_for_processing,core.configuration.config_registry.get_path_config
 core\storage\upload_local.prepare_document_for_processing,core\storage\upload_local.file_path.read_bytes
 core\storage\upload_local.prepare_document_for_processing,core.parsing.extract_text.extract_text
 core\storage\upload_local.prepare_document_for_processing,core\storage\upload_local.str
@@ -964,7 +964,7 @@ core\storage\upload_s3.push_document_to_s3,core.parsing.extract_text.extract_tex
 core\storage\upload_s3.push_document_to_s3,core\storage\upload_s3.s3.upload_file
 core\storage\upload_s3.push_document_to_s3,core\storage\upload_s3.s3.put_object
 core\storage\upload_s3.push_document_to_s3,core\storage\upload_s3.s3.put_object
-core\storage\upload_s3.push_document_to_s3,core.config.remote_config.RemoteConfig.from_file
+core\storage\upload_s3.push_document_to_s3,core.configuration.remote_config.RemoteConfig.from_file
 core\storage\upload_s3.push_document_to_s3,core\storage\upload_s3.str
 core\storage\upload_s3.push_document_to_s3,core\storage\upload_s3.str
 core\storage\upload_s3.push_document_to_s3,core\storage\upload_s3.file_path.suffix.lower.lstrip
@@ -1064,7 +1064,7 @@ core\vectorstore\faiss_store.persist,faiss.write_index
 core\vectorstore\faiss_store.persist,core\vectorstore\faiss_store.str
 core\vectorstore\faiss_store._load,faiss.read_index
 core\vectorstore\faiss_store._load,core\vectorstore\faiss_store.str
-core\workflows\main_commands.get_parsed_text,core.config.config_registry.get_path_config
+core\workflows\main_commands.get_parsed_text,core.configuration.config_registry.get_path_config
 core\workflows\main_commands.get_parsed_text,core\workflows\main_commands.parsed_path.read_text
 core\workflows\main_commands.looks_like_chatlog,core\workflows\main_commands.text.lower.splitlines
 core\workflows\main_commands.looks_like_chatlog,core\workflows\main_commands.sum
@@ -1092,9 +1092,9 @@ core\workflows\main_commands.classify,core\workflows\main_commands.detect
 core\workflows\main_commands.classify,core\workflows\main_commands.summarize
 core\workflows\main_commands.classify,core\workflows\main_commands.merge_stubs
 core\workflows\main_commands.classify,core\workflows\main_commands.persist
-core\workflows\main_commands.classify,core.config.config_registry.get_path_config
+core\workflows\main_commands.classify,core.configuration.config_registry.get_path_config
 core\workflows\main_commands.classify,core\workflows\main_commands.segment
-core\workflows\main_commands.upload_metadata_to_s3,core.config.config_registry.get_remote_config
+core\workflows\main_commands.upload_metadata_to_s3,core.configuration.config_registry.get_remote_config
 core\workflows\main_commands.upload_metadata_to_s3,core.storage.s3_utils.save_metadata_s3
 core\workflows\main_commands.upload_and_prepare,core.storage.upload_local.upload_file
 core\workflows\main_commands.pipeline_from_upload,core\workflows\main_commands.upload_and_prepare
@@ -1103,7 +1103,7 @@ core\workflows\main_commands.pipeline_from_upload,pathlib.Path.stem.replace.repl
 core\workflows\main_commands.pipeline_from_upload,pathlib.Path.stem.replace.replace
 core\workflows\main_commands.pipeline_from_upload,pathlib.Path.stem.replace
 core\workflows\main_commands.pipeline_from_upload,pathlib.Path
-gui\chat_gui.run_openai_chat,core.config.config_registry.get_remote_config
+gui\chat_gui.run_openai_chat,core.configuration.config_registry.get_remote_config
 gui\chat_gui.run_openai_chat,openai.OpenAI
 gui\chat_gui.run_openai_chat,core.utils.budget_tracker.get_budget_tracker
 gui\chat_gui.run_openai_chat,gui\chat_gui.client.chat.completions.create
@@ -1144,7 +1144,7 @@ scripts\pipeline.run_pipeline,scripts\pipeline.logger.info
 scripts\pipeline.run_pipeline,scripts\pipeline.sorted
 scripts\pipeline.run_pipeline,scripts\pipeline.embed_document
 scripts\pipeline.run_pipeline,scripts\pipeline.logger.info
-scripts\pipeline.run_pipeline,core.config.config_registry.get_path_config
+scripts\pipeline.run_pipeline,core.configuration.config_registry.get_path_config
 scripts\pipeline.run_pipeline,scripts\pipeline.input_dir.glob
 scripts\pipeline.run_pipeline,scripts\pipeline.upload_file
 scripts\pipeline.run_pipeline,scripts\pipeline.paths.parsed.glob

--- a/src/core/clustering/labeling.py
+++ b/src/core/clustering/labeling.py
@@ -52,7 +52,7 @@ from typing import Dict, List
 
 from openai import OpenAI
 
-from core.config.config_registry import get_remote_config
+from core.configuration.config_registry import get_remote_config
 from core.logger import get_logger
 
 logger = get_logger(__name__)

--- a/src/core/configuration/config_registry.py
+++ b/src/core/configuration/config_registry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 from .path_config import PathConfig
 from .remote_config import RemoteConfig
@@ -11,25 +11,42 @@ from .remote_config import RemoteConfig
 _path_instance: Optional[PathConfig] = None
 _remote_instance: Optional[RemoteConfig] = None
 
-path_config: Optional[Path] = Path(__file__).with_name("path_config.json")
-remote_config: Optional[Path] = Path(__file__).with_name("remote_config.json")
+_DEFAULT_PATH_CONFIG_PATH = (
+    Path(__file__).with_name("path_config.json").expanduser().resolve(strict=False)
+)
+_DEFAULT_REMOTE_CONFIG_PATH = (
+    Path(__file__).with_name("remote_config.json").expanduser().resolve(strict=False)
+)
+
+path_config: Optional[Path] = _DEFAULT_PATH_CONFIG_PATH
+remote_config: Optional[Path] = _DEFAULT_REMOTE_CONFIG_PATH
+
+_UNSET = object()
 
 
 def configure(
     *,
-    path_config_path: Optional[Path] = None,
-    remote_config_path: Optional[Path] = None,
+    path_config_path: Union[Path, str, None, object] = _UNSET,
+    remote_config_path: Union[Path, str, None, object] = _UNSET,
 ) -> None:
     """Override the filesystem locations for configuration files."""
 
     global path_config, remote_config, _path_instance, _remote_instance
 
-    if path_config_path is not None:
-        path_config = Path(path_config_path)
+    if path_config_path is not _UNSET:
+        if path_config_path is None:
+            path_config = _DEFAULT_PATH_CONFIG_PATH
+        else:
+            path_config = Path(path_config_path).expanduser().resolve(strict=False)
         _path_instance = None
 
-    if remote_config_path is not None:
-        remote_config = Path(remote_config_path)
+    if remote_config_path is not _UNSET:
+        if remote_config_path is None:
+            remote_config = _DEFAULT_REMOTE_CONFIG_PATH
+        else:
+            remote_config = Path(remote_config_path).expanduser().resolve(
+                strict=False
+            )
         _remote_instance = None
 
 

--- a/src/core/configuration/path_config.json
+++ b/src/core/configuration/path_config.json
@@ -5,6 +5,5 @@
   "metadata": "metadata",
   "output": "output",
   "vector": "vector",
-  "schema": "src/core/configuration/metadata_schema.json",
   "semantic_chunking": false
 }

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Dict
 
 # --------------------------------------------------------------------------- #
@@ -19,8 +20,13 @@ DEFAULT_S3_PREFIXES: Dict[str, str] = {
 DEFAULT_S3_DOWNLOAD_PREFIX: str = DEFAULT_S3_PREFIXES["raw"]
 """Default prefix used when downloading files from S3."""
 
-DEFAULT_METADATA_SCHEMA_PATH: str = "config/metadata_schema.json"
-"""Relative path to the default metadata schema file."""
+_DEFAULT_SCHEMA_RELATIVE = Path("core/configuration/metadata_schema.json")
+DEFAULT_METADATA_SCHEMA_PATH: Path = (
+    (Path(__file__).resolve().parents[1] / _DEFAULT_SCHEMA_RELATIVE)
+    .expanduser()
+    .resolve(strict=False)
+)
+"""Absolute path to the default metadata schema file."""
 
 # --------------------------------------------------------------------------- #
 #  Error message templates

--- a/src/core/memory/frame_store.py
+++ b/src/core/memory/frame_store.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import Optional
 
-from core.config.config_registry import get_path_config
+from core.configuration.config_registry import get_path_config
 
 
 class FrameStore:

--- a/src/core/metadata/schema.py
+++ b/src/core/metadata/schema.py
@@ -44,7 +44,8 @@ from pathlib import Path
 
 from jsonschema import validate
 
-from core.config.config_registry import get_path_config
+from core.configuration.config_registry import get_path_config
+from core.configuration.path_config import validate_schema_path
 from core.constants import ERROR_SCHEMA_FILE_NOT_FOUND
 from core.logger import get_logger
 
@@ -64,7 +65,7 @@ def validate_metadata(metadata: dict) -> None:
         FileNotFoundError: If schema path is missing or invalid.
     """
     paths = get_path_config()
-    schema_path = Path(paths.schema)
+    schema_path = validate_schema_path(paths.schema)
     logger.info("Using schema path: %s", schema_path)
 
     if not schema_path.exists():

--- a/src/core/retrieval/retriever.py
+++ b/src/core/retrieval/retriever.py
@@ -4,7 +4,7 @@ from typing import Iterable, List, Tuple, cast
 
 import numpy as np
 
-from core.config.config_registry import get_path_config
+from core.configuration.config_registry import get_path_config
 from core.embeddings.embedder import MODEL_DIMS, embed_text, get_model_for_dim
 from core.logger import get_logger
 from core.vectorstore.faiss_store import FaissStore

--- a/src/core/storage/upload_local.py
+++ b/src/core/storage/upload_local.py
@@ -1,8 +1,8 @@
 import json
 from pathlib import Path
 
-from core.config.config_registry import get_path_config
-from core.config.path_config import PathConfig
+from core.configuration.config_registry import get_path_config
+from core.configuration.path_config import PathConfig
 from core.logger import get_logger
 from core.parsing.extract_text import extract_text
 

--- a/src/core/storage/upload_s3.py
+++ b/src/core/storage/upload_s3.py
@@ -1,8 +1,8 @@
 import json
 from pathlib import Path
 
-from core.config.config_registry import get_path_config
-from core.config.remote_config import RemoteConfig
+from core.configuration.config_registry import get_path_config
+from core.configuration.remote_config import RemoteConfig
 from core.parsing.extract_text import extract_text
 from core.storage.aws_clients import get_s3_client
 

--- a/src/core/workflows/main_commands.py
+++ b/src/core/workflows/main_commands.py
@@ -48,8 +48,8 @@ import json
 from pathlib import Path
 from typing import Literal, Optional
 
-from core.config.config_registry import get_path_config, get_remote_config
-from core.config.path_config import PathConfig
+from core.configuration.config_registry import get_path_config, get_remote_config
+from core.configuration.path_config import PathConfig
 from core.llm.invoke import summarize_text
 from core.metadata.merge import merge_metadata_blocks
 from core.metadata.schema import validate_metadata

--- a/src/gui/chat_gui.py
+++ b/src/gui/chat_gui.py
@@ -8,7 +8,7 @@ import streamlit as st  # type: ignore
 import tiktoken
 from openai import OpenAI
 
-from core.config.config_registry import get_remote_config
+from core.configuration.config_registry import get_remote_config
 from core.llm.invoke import LLM_COMPLETION_COST_PER_1K  # type: ignore
 from core.llm.invoke import LLM_PROMPT_COST_PER_1K
 from core.utils.budget_tracker import get_budget_tracker  # type: ignore

--- a/tests/test_config_registry_schema_override.py
+++ b/tests/test_config_registry_schema_override.py
@@ -1,0 +1,112 @@
+"""Regression tests for schema-aware path configuration."""
+
+from __future__ import annotations
+
+import json
+import importlib
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from cli import pipeline as pipeline_cli
+from core.configuration.path_config import PathConfig, validate_schema_path
+from core.constants import DEFAULT_METADATA_SCHEMA_PATH
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def restore_registry_state():
+    """Reload the registry module between tests to avoid cross-test bleed."""
+    module = importlib.reload(importlib.import_module("core.configuration.config_registry"))
+    try:
+        yield module
+    finally:
+        importlib.reload(importlib.import_module("core.configuration.config_registry"))
+
+
+def test_configure_resets_to_default(tmp_path: Path):
+    """Explicit ``None`` overrides should restore default config paths."""
+    registry = importlib.import_module("core.configuration.config_registry")
+
+    config_path = tmp_path / "path_config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "root": str(tmp_path),
+                "raw": "raw",
+                "parsed": "parsed",
+                "metadata": "metadata",
+                "output": "output",
+                "vector": "vector",
+                "semantic_chunking": False,
+            }
+        )
+    )
+
+    registry.configure(path_config_path=config_path)
+    loaded = registry.get_path_config(force_reload=True)
+    assert loaded.root == Path(tmp_path)
+
+    registry.configure(path_config_path=None)
+    restored = registry.get_path_config(force_reload=True)
+    assert registry.path_config == registry._DEFAULT_PATH_CONFIG_PATH
+    assert validate_schema_path(restored.schema) == DEFAULT_METADATA_SCHEMA_PATH
+    assert registry.get_path_config() is restored
+
+
+def test_validate_schema_path_warns_and_falls_back(tmp_path: Path, caplog: pytest.LogCaptureFixture):
+    """Missing schema files log a warning and fall back to the default path."""
+    missing = tmp_path / "missing-schema.json"
+    caplog.set_level("WARNING")
+
+    resolved = validate_schema_path(missing)
+    assert resolved == DEFAULT_METADATA_SCHEMA_PATH
+    assert any("Metadata schema not found" in record.message for record in caplog.records)
+
+
+def test_cli_pipeline_uses_cached_schema(tmp_path: Path, caplog: pytest.LogCaptureFixture):
+    """CLI invocation should reuse cached schema resolution when composing PathConfig."""
+    caplog.set_level("INFO")
+    base = PathConfig(root=tmp_path, schema=tmp_path / "nonexistent.json")
+
+    input_dir = tmp_path / "incoming"
+    input_dir.mkdir()
+
+    captured: dict[str, Path] = {}
+
+    def fake_run_pipeline(*, paths: PathConfig, **kwargs):
+        captured["schema"] = paths.schema
+        return None
+
+    def fake_run_all_steps(**kwargs):
+        return None
+
+    registry = importlib.import_module("core.configuration.config_registry")
+    registry.configure(path_config_path=None)
+
+    original_get = pipeline_cli.get_path_config
+    original_run_pipeline = pipeline_cli.run_pipeline
+    original_run_all_steps = pipeline_cli.run_all_steps
+    try:
+        pipeline_cli.get_path_config = lambda: base  # type: ignore[assignment]
+        pipeline_cli.run_pipeline = fake_run_pipeline  # type: ignore[assignment]
+        pipeline_cli.run_all_steps = fake_run_all_steps  # type: ignore[assignment]
+
+        result = runner.invoke(
+            pipeline_cli.app,
+            [
+                "--input-dir",
+                str(input_dir),
+            ],
+        )
+    finally:
+        pipeline_cli.get_path_config = original_get  # type: ignore[assignment]
+        pipeline_cli.run_pipeline = original_run_pipeline  # type: ignore[assignment]
+        pipeline_cli.run_all_steps = original_run_all_steps  # type: ignore[assignment]
+
+    assert result.exit_code == 0
+    assert captured["schema"] == base.schema
+    assert base.schema == DEFAULT_METADATA_SCHEMA_PATH
+    assert any("Metadata schema not found" in record.message for record in caplog.records)

--- a/tests/test_doc_drift.py
+++ b/tests/test_doc_drift.py
@@ -1,0 +1,74 @@
+"""Ensure purpose documentation tracks AST-level dependencies."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+MODULE_PURPOSE = {
+    "core.retrieval.retriever": Path(
+        "Codex_++/purpose_files/core.retrieval.retriever.purpose.md"
+    ),
+    "core.embeddings.embedder": Path(
+        "Codex_++/purpose_files/core.embeddings.embedder.purpose.md"
+    ),
+    "core.configuration.path_config": Path(
+        "Codex_++/purpose_files/core.configuration.path_config.purpose.md"
+    ),
+    "core.configuration.config_registry": Path(
+        "Codex_++/purpose_files/core.configuration.config_registry.purpose.md"
+    ),
+    "core.constants": Path("Codex_++/purpose_files/core.constants.purpose.md"),
+}
+
+ALIAS_PREFIX = {
+    "path_config": "core.configuration.path_config",
+    "remote_config": "core.configuration.remote_config",
+}
+
+
+def _normalize_dependency(raw: str) -> str:
+    raw = raw.replace("\\", ".")
+    if raw.startswith("builtins"):
+        return ""
+    parts = raw.split(".")
+    if parts[0] in {"typing"}:
+        return ""
+    if parts[0] in ALIAS_PREFIX:
+        return ALIAS_PREFIX[parts[0]]
+    if parts[0] == "core":
+        if len(parts) >= 3:
+            return ".".join(parts[:3])
+        return ".".join(parts)
+    return parts[0]
+
+
+def _read_ast_dependencies(module: str) -> set[str]:
+    deps: set[str] = set()
+    with Path("ast_deps.csv").open(newline="") as handle:
+        reader = csv.reader(handle)
+        for src, dest in reader:
+            src_module = src.replace("\\", ".").rsplit(".", 1)[0]
+            if src_module != module:
+                continue
+            norm = _normalize_dependency(dest)
+            if not norm or norm == module:
+                continue
+            deps.add(norm)
+    return deps
+
+
+def _read_doc_dependencies(path: Path) -> set[str]:
+    for line in path.read_text().splitlines():
+        if line.startswith("- @ai-dependencies:"):
+            _, _, payload = line.partition(":")
+            return {dep.strip() for dep in payload.split(",") if dep.strip()}
+    raise AssertionError(f"Missing @ai-dependencies tag in {path}")
+
+
+def test_purpose_dependencies_match_ast():
+    for module, doc_path in MODULE_PURPOSE.items():
+        ast_deps = _read_ast_dependencies(module)
+        doc_deps = _read_doc_dependencies(doc_path)
+        missing = ast_deps - doc_deps
+        assert not missing, f"{module} missing dependencies: {sorted(missing)}"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -26,7 +26,6 @@ path_config_path.write_text(
             "metadata": "metadata",
             "output": "output",
             "vector": "vector",
-            "schema": "config/metadata_schema.json",
             "semantic_chunking": False,
         }
     )
@@ -130,7 +129,6 @@ def sample_paths(tmp_path: Path) -> PathConfig:
         metadata=metadata_dir,
         output=output_dir,
         vector=vector_dir,
-        schema=tmp_path / "config" / "metadata_schema.json",
         semantic_chunking=True,
     )
 


### PR DESCRIPTION
## Summary
- centralize metadata schema resolution via `validate_schema_path`, absolute defaults, and unified `core.configuration` imports across retrieval, embeddings, storage, and workflow modules
- refresh Trace A design memory by regenerating purpose files for configuration, embeddings, retrieval, and constants plus recording decisions in a new intent
- add regression coverage for config override resets, CLI schema reuse, and purpose/AST drift detection alongside updated pipeline fixtures

## Testing
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68d8930ee73c8323b042d21e5d7663bc