### PR TITLE
Refactor pipeline to enforce chunk-first workflow

### DIFF
--- a/Codex_++/purpose_files/core.storage.upload_local.purpose.md
+++ b/Codex_++/purpose_files/core.storage.upload_local.purpose.md
@@ -7,28 +7,33 @@
 # Follow AGENTS.md G-10 and Section 9 enrichment instructions.
 
 # Module: core.storage.upload_local
-# @ai-path: core.storage.upload_local
-# @ai-source-file: upload_local.py
-# @ai-role: Local Ingestion Utility
-# @ai-intent: "Convert documents to text and save stubs on the local filesystem."
-
-> Provides helper functions to parse raw files into `.txt` and generate stub metadata.
+> Convert raw documents into parsed text and emit structured stubs for downstream pipelines.
 
 ### 🎯 Intent & Responsibility
-- Prepare local documents for classification workflows.
-- Accept optional `PathConfig` overrides for flexible directory layout.
+- Copy raw documents into the configured `PathConfig.raw` directory and extract plain-text representations under `parsed`.
+- Generate rich stub metadata capturing `file_info` (paths, extension, counts) and a placeholder `chunk_map` used by classification.
+- Ensure ingestion directories exist, supporting both default and custom `PathConfig` layouts.
 
 ### 📥 Inputs & 📤 Outputs
 | Direction | Name | Type | Description |
 |-----------|------|------|-------------|
-| 📥 In | file_path | Path | Path to the source file |
-| 📥 In | parsed_name | str | Optional name for `.txt` output |
-| 📥 In | paths | PathConfig | Optional directory configuration |
-| 📤 Out | stub | dict | Mapping of raw and parsed file paths |
+| 📥 In | file_path | Path | Source document to ingest |
+| 📥 In | parsed_name | Optional[str] | Override for parsed `.txt` filename |
+| 📥 In | paths | PathConfig | Directory configuration (defaults to registry) |
+| 📤 Out | stub | Dict[str, Any] | `{ "file_info": {...}, "chunk_map": None }` persisted to `<parsed_name>.stub.json` |
+| 📤 Out | parsed_file | Path | Parsed `.txt` written to `paths.parsed` |
 
 ### 🔗 Dependencies
-- `core.parsing.extract_text`
-- `core.config.config_registry.get_path_config`
+- `core.parsing.extract_text` — performs format-specific text extraction.
+- `core.configuration.config_registry.get_path_config` — supplies default directory structure.
 
 ### 🗣 Dialogic Notes
-- Called by CLI utilities and pipeline steps during ingestion.
+- `file_info` now records `source_file`, `parsed_file`, `source_ext`, `word_count`, and `char_count`, enabling later analytics without re-reading the raw document.
+- `chunk_map` placeholder allows classification to detect whether chunk planning has been performed; subsequent stages overwrite `None` with detailed plans.
+- Called by CLI/pipeline ingestion steps; errors surface early before expensive LLM calls.
+
+### 9 Pipeline Integration
+- @ai-pipeline-order: inverse
+- **Coordination Mechanics:** Provides the initial artefacts consumed by `core.workflows.main_commands.prepare_chunk_plan` and the broader `scripts.pipeline` run.
+- **Integration Points:** Stub structure is read/updated by classification, embeddings, and clustering stages to keep metadata aligned.
+- **Risks:** Extraction failures halt ingestion; stub schema must evolve in lockstep with metadata validation.

--- a/Codex_++/purpose_files/core_workflows_main_commands.purpose.md
+++ b/Codex_++/purpose_files/core_workflows_main_commands.purpose.md
@@ -1,42 +1,43 @@
 # Module: core.workflows.main_commands
-> Orchestrates full document classification pipeline—parsing, summarization, metadata validation, and S3 integration—via Claude-based LLM workflows.
+> Orchestrates document preparation, chunk planning, LLM summarisation, and metadata persistence for ingestion pipelines.
 
 ### 🎯 Intent & Responsibility
-- Coordinate document ingestion, classification, and metadata generation.
-- Dynamically route input through chunked or standard summarization based on content size and format.
-- Validate and merge output into `.meta.json`, locally or on S3.
+- Generate deterministic chunk plans for parsed documents, persisting them alongside stubs for reuse.
+- Summarise chunk records via the configured prompt, merge outputs into document-level metadata, and validate the enriched payload.
+- Maintain `chunk_map`, per-chunk summaries, and optional `cluster` annotations while respecting existing stub overrides.
 
 ### 📥 Inputs & 📤 Outputs
-| Direction | Name             | Type              | Brief Description                                                                    |
-|-----------|------------------|-------------------|---------------------------------------------------------------------------------------|
-| 📥 In     | file_name         | str               | Raw input file path (PDF, DOCX, etc.)                                                |
-| 📥 In     | parsed_name       | Optional[str]     | Custom filename for parsed `.txt` version                                            |
-| 📥 In     | name              | str               | Name of parsed file (e.g., `foo.txt`)                                                |
-| 📥 In     | segmentation      | str               | "semantic" or "paragraph" segmentation strategy |
-| 📤 Out    | metadata          | dict              | Structured JSON metadata saved locally or uploaded to S3                             |
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | file_name | str | Raw path consumed by `upload_and_prepare` |
+| 📥 In | parsed_name | Optional[str] | Override for parsed `.txt` output |
+| 📥 In | name | str | Parsed filename passed to `classify`/`prepare_chunk_plan` |
+| 📥 In | segmentation | Literal[`semantic`,`paragraph`] | Chunking strategy used for planning |
+| 📥 In | chunk_records | Optional[List[Dict[str, Any]]] | Pre-computed chunk metadata (includes text + offsets) reused during classification |
+| 📤 Out | metadata | Dict[str, Any] | `.meta.json` including schema-required fields plus `file_info`, `chunk_map`, `chunks`, and optional `cluster` |
+| 📤 Out | chunk metadata | List[Dict[str, Any]] | `<name>.chunks.json` persisted for resume operations |
+| 📤 Out | stub | Dict[str, Any] | `.stub.json` updated with structured `file_info` + `chunk_map` summary |
 
 ### 🔗 Dependencies
-- `core.llm.summarize_text` – for Claude-based document classification
-- `core.parsing.chunk_text` – for breaking up long documents
-- `core.metadata.schema` – for metadata validation
-- `core.metadata.merge` – for combining chunk-level summaries
-- `core.storage.s3_utils` – for metadata upload to S3
-- `core.config.{path_config, remote_config}` – for paths and cloud config
+- `core.parsing.topic_segmenter` / `core.parsing.chunk_text` — build semantic or paragraph chunk sequences capped by the context window.
+- `core.llm.invoke.summarize_text` — produce per-chunk JSON summaries.
+- `core.metadata.merge.merge_metadata_blocks` — collapse chunk-level metadata into document-level aggregates.
+- `core.metadata.schema.validate_metadata` — enforce enriched schema (chunk + cluster fields).
+- `core.storage.upload_local` — seeds stubs consumed and rewritten during classification.
 
 ### ⚙️ AI-Memory Tags
-- `@ai-assumes:` LLM summarization output conforms to expected metadata schema.
-- `@ai-breakage:` Chunking strategy or Lambda output structure changes can cause downstream merging to fail.
-- `@ai-risks:` Stub merging may overwrite key fields unless preemptively managed.
+- `@ai-assumes:` Chunk metadata includes `text` content; stub `chunk_map` mirrors the saved chunk plan.
+- `@ai-breakage:` Segmentation mismatches between planning and embeddings will desynchronise chunk indices.
+- `@ai-risks:` Stub merges can clobber LLM output; schema drift must be mirrored before validation.
 
 ### 🗣 Dialogic Notes
-- `detect()`, `segment()`, `summarize()`, `merge_stubs()`, and `persist()` decompose `classify()` into testable steps (routing, chunking, summarization, stub overlay, validation/write).
-- Supports optional `segmentation` choice to use semantic or paragraph boundaries.
-- `pipeline_from_upload()` provides a single-call ingestion-to-metadata interface.
-- Works with either local-only or hybrid S3-local workflows.
-- Meant to decouple CLI and backend logic, enabling reuse in batch processing or UIs.
+- `prepare_chunk_plan()` handles chunk caching, stub updates, and disk writes; `load_chunk_metadata()` reloads artefacts for resume workflows.
+- `classify()` accepts optional chunk records, guarantees chunking for texts beyond `MAX_CHARS`, and attaches per-chunk metadata under `chunks`.
+- Updated stubs expose structured `file_info` and `chunk_map`, enabling embedding/clustering stages to align on identical chunk layouts.
+- Chunk records preserve order, char spans, and summary payloads, supporting retrieval and visualisation layers downstream.
 
 ### 9 Pipeline Integration
 - @ai-pipeline-order: inverse
-- **Coordination Mechanics:** Wraps parsing, topic segmentation, summarization, and embedding into a single flow. Metadata output guides downstream retrieval and synthesis.
-- **Integration Points:** Relies on `core.parsing.topic_segmenter`, `core.embeddings.embedder`, and feeds results to Retriever and Synthesizer loops, plus TokenMap Analyzer for audit.
-- **Risks:** Misconfigured segmentation or missing metadata can derail later search and summarization stages; long documents increase OpenAI costs.
+- **Coordination Mechanics:** `prepare_chunk_plan → summarize_records → merge_stubs → persist` ensures chunk artefacts exist before summarisation, keeping embeddings and clustering consistent.
+- **Integration Points:** Results feed into `scripts.pipeline`, `core.embeddings.embedder` (chunk-aware embeddings), and clustering modules which append `cluster` info.
+- **Risks:** Missing chunk metadata when resuming from later stages triggers regeneration and may diverge from stored embeddings; monitor schema alignment for `chunk_map`/`chunks`.

--- a/Codex_++/purpose_files/scripts.pipeline.purpose.md
+++ b/Codex_++/purpose_files/scripts.pipeline.purpose.md
@@ -1,42 +1,45 @@
-    # Module: scripts.pipeline
-> Orchestrates the full local-to-cloud document processing pipeline—upload, classification, and embedding—via a single CLI-executable function.
+# Module: scripts.pipeline
+> Drives the ingestion pipeline end-to-end: upload, chunk planning, classification, embeddings, clustering, and logging.
 
 ### 🎯 Intent & Responsibility
-- Serve as a one-stop execution layer for the full LLM-powered pipeline.
-- Ingest files from a local folder, route them through upload + parsing → classification → embedding stages.
-- Handle optional chunked summarization and overwrite behavior for idempotent operation.
-- Expose `upload_file`, `classify_document`, and `embed_document` helpers that encapsulate each stage for reuse and testing.
+- Provide a resumable orchestration layer over upload, chunking, classification, embedding, and clustering stages.
+- Persist detailed run logs under `PathConfig.root/logs`, emitting concise console updates while retaining diagnostics in file.
+- Bridge chunk metadata from `core.workflows.main_commands` into embeddings and clustering so downstream artefacts stay aligned.
 
 ### 📥 Inputs & 📤 Outputs
-| Direction | Name         | Type     | Brief Description                                                               |
-|-----------|--------------|----------|----------------------------------------------------------------------------------|
-| 📥 In     | input_dir     | Path     | Directory containing raw documents                                               |
-| 📥 In     | chunked       | bool     | Whether to use paragraph-based chunking during classification                    |
-| 📥 In     | overwrite     | bool     | Whether to reprocess files that already have a `.meta.json`                     |
-| 📥 In     | method        | str      | Embedding source: `parsed`, `summary`, `raw`, or `meta`                         |
-| 📤 Out    | stdout log    | str/log  | Upload, classification, and embedding progress per document                     |
-| 📤 Out    | output files  | Files    | `.parsed.txt`, `.meta.json`, and `.embedding.json` per document (local or S3)   |
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | input_dir | Path | Root directory containing raw documents to ingest |
+| 📥 In | chunked | bool | Force chunking even when under the context window |
+| 📥 In | overwrite | bool | Reclassify documents that already have `.meta.json` |
+| 📥 In | method | str | Embedding source text (`parsed`, `summary`, `raw`, `meta`) |
+| 📥 In | segmentation | str | Chunk segmentation strategy (`semantic`/`paragraph`) |
+| 📥 In | start_from | str | Stage to resume from (`upload`, `chunk`, `classify`, `embed`, `cluster`) |
+| 📥 In | cluster_method | str | Clustering algorithm (`hdbscan`, `spectral`, …) |
+| 📥 In | label_model | str | OpenAI model for cluster labeling |
+| 📤 Out | logs | File & stdout | Timestamped log file under `<root>/logs/` plus concise console progress |
+| 📤 Out | artefacts | Files | Updated stubs, chunk metadata, `.meta.json`, embeddings JSON, cluster exports |
 
 ### 🔗 Dependencies
-- `core.config.config_registry.get_path_config`
-- `core.workflows.main_commands.{upload_and_prepare, classify}`
-- `core.embeddings.embedder.generate_embeddings`
+- `core.configuration.config_registry.get_path_config` for environment-scoped directories.
+- `core.workflows.main_commands` (upload, chunk planning, classification) to produce metadata and chunk records.
+- `core.embeddings.embedder.generate_embeddings` for vector generation.
+- `core.embeddings.loader`, `core.clustering.algorithms`, `core.clustering.labeling`, `core.clustering.export` for clustering/visuals.
+- `core.metadata.schema.validate_metadata` to ensure cluster annotations keep metadata valid.
 
 ### ⚙️ AI-Memory Tags
-- `@ai-assumes:` Parsed and metadata folders exist and are writable.
-- `@ai-breakage:` Output format changes or schema shifts in `.meta.json` or embedding source text.
-- `@ai-risks:` Skipping classification due to existing `.meta.json` could propagate stale metadata unless `overwrite=True`.
+- `@ai-assumes:` Chunk metadata includes `text`; embeddings file is JSON mapping doc/chunk ids to vectors.
+- `@ai-breakage:` Missing optional dependencies (`umap`, `hdbscan`) gracefully skip clustering but leave previous outputs untouched.
+- `@ai-risks:` Starting from later stages without up-to-date chunk metadata may regenerate segments—warn in logs.
 
 ### 🗣 Dialogic Notes
-- This is the operational entry point for batch processing; ideal for CLI runners, cron jobs, or one-off runs.
-- Handles exceptions gracefully at each step; doesn’t halt pipeline on single failure.
-- Embedding method can be aligned with downstream semantic search or classification heuristics.
-- Embedding segmentation now respects `PathConfig.semantic_chunking` for topic vs. paragraph mode.
-- Could be expanded to support logging, dry-run mode, or parallel processing.
-- When embeddings are generated, vectors are simultaneously added to the FAISS index for immediate searchability.
+- Stage helpers (`_run_upload_stage`, `_run_chunk_stage`, `_run_classification_stage`, `_run_embedding_stage`, `_run_cluster_stage`) encapsulate retry-friendly logic.
+- `_setup_pipeline_logger()` records full diagnostics to disk; console output stays succinct per stage.
+- `_load_chunk_cache()` allows resumes from `classify`/`embed`/`cluster` without re-running earlier steps, relying on saved chunk artefacts.
+- Clustering attaches labels back into metadata via the new `cluster` field and exports summary CSV/plot assets.
 
 ### 9 Pipeline Integration
 - @ai-pipeline-order: inverse
-- **Coordination Mechanics:** Runs end-to-end steps—upload, parse, segment, summarize, embed—ensuring outputs are synchronized before index update.
-- **Integration Points:** Utilizes `core.embeddings.embedder`, `core.retrieval.retriever`, and passes metadata to Synthesizer and TokenMap Analyzer modules.
-- **Risks:** Pipeline failures at any step can leave partial outputs; large document batches magnify OpenAI costs and GPU usage.
+- **Coordination Mechanics:** Upload → chunk plan → classify → embed → cluster; each stage reads/writes artefacts consumed by the next and can be resumed midstream via `start_from`.
+- **Integration Points:** Feeds chunk records to the embedder, embeddings to clustering, and writes cluster info back to `.meta.json`.
+- **Risks:** Skipped stages rely on artefacts produced earlier; manual edits or deletions can desynchronise embeddings/clusters from metadata.

--- a/src/cli/pipeline.py
+++ b/src/cli/pipeline.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import typer
 
-from core.clustering.clustering_steps import run_all_steps
 from core.configuration.config_registry import get_path_config
 from core.configuration.path_config import PathConfig
 from scripts.pipeline import run_pipeline
@@ -39,6 +38,11 @@ def run_all(
     method: str = "summary",
     cluster_method: str = "hdbscan",
     model: str = "gpt-4",
+    start_from: str = typer.Option(
+        "upload",
+        help="Resume the pipeline from a specific stage",
+        show_default=True,
+    ),
     root: Path | None = typer.Option(None, help="Override root directory"),
     raw_dir: Path | None = typer.Option(None, help="Raw documents directory"),
     parsed_dir: Path | None = typer.Option(None, help="Parsed documents directory"),
@@ -54,7 +58,6 @@ def run_all(
     """
     paths = _resolve_paths(root, raw_dir, parsed_dir, metadata_dir, output_dir)
 
-    # Steps 1–3
     run_pipeline(
         input_dir=input_dir,
         chunked=chunked,
@@ -62,13 +65,7 @@ def run_all(
         overwrite=True,
         segmentation=segmentation,
         paths=paths,
-    )
-
-    # Step 4
-    run_all_steps(
-        embedding_path=paths.root / "rich_doc_embeddings.json",
-        metadata_dir=paths.metadata,
-        out_dir=paths.output / "cluster_output",
-        method=cluster_method,
-        model=model,
+        start_from=start_from,
+        cluster_method=cluster_method,
+        label_model=model,
     )

--- a/src/core/configuration/metadata_schema.json
+++ b/src/core/configuration/metadata_schema.json
@@ -104,6 +104,130 @@
         }
       }
     },
+    "chunk_map": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "strategy": {
+          "type": "string"
+        },
+        "context_window": {
+          "type": "integer"
+        },
+        "count": {
+          "type": "integer"
+        },
+        "chunks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "order": {
+                "type": "integer"
+              },
+              "char_start": {
+                "type": "integer"
+              },
+              "char_end": {
+                "type": "integer"
+              },
+              "char_length": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "id",
+              "order"
+            ]
+          }
+        }
+      }
+    },
+    "chunks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer"
+          },
+          "strategy": {
+            "type": "string"
+          },
+          "char_length": {
+            "type": "integer"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "topics": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "themes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "priority": {
+            "type": "integer"
+          },
+          "tone": {
+            "type": "string"
+          },
+          "stage": {
+            "type": "string"
+          },
+          "depth": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "order",
+          "strategy"
+        ]
+      }
+    },
+    "cluster": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "label",
+        "method"
+      ]
+    },
     "custom": {
       "type": "object",
       "properties": {

--- a/src/core/storage/upload_local.py
+++ b/src/core/storage/upload_local.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any, Dict
 
 from core.configuration.config_registry import get_path_config
 from core.configuration.path_config import PathConfig
@@ -9,13 +10,31 @@ from core.parsing.extract_text import extract_text
 logger = get_logger(__name__)
 
 
+def _build_file_info(
+    *,
+    source_path: Path,
+    parsed_path: Path,
+    text: str,
+) -> Dict[str, Any]:
+    """Return structured file metadata stored alongside classification output."""
+
+    words = text.split()
+    return {
+        "source_file": str(source_path),
+        "parsed_file": str(parsed_path),
+        "source_ext": source_path.suffix.lower().lstrip("."),
+        "word_count": len(words),
+        "char_count": len(text),
+    }
+
+
 def prepare_document_for_processing(
     file_path: Path,
     parsed_name: str | None = None,
     paths: PathConfig | None = None,
 ) -> dict:
     """
-    Convert a raw document into parsed text and save a stub locally.
+    Convert a raw document into parsed text and save a structured stub locally.
 
     Args:
         file_path (Path): Full path to the raw file
@@ -23,7 +42,7 @@ def prepare_document_for_processing(
         paths (PathConfig | None): Directory configuration override
 
     Returns:
-        dict: Stub metadata linking source and parsed files
+        dict: Stub metadata containing file information and chunk placeholder
     """
     file_path = Path(file_path)
     paths = paths or get_path_config()
@@ -37,11 +56,9 @@ def prepare_document_for_processing(
         or file_path.stem.replace(" ", "_").replace("-", "_").lower() + ".txt"
     )
 
-    # Copy raw file
     dest_raw = paths.raw / original_name
     dest_raw.write_bytes(file_path.read_bytes())
 
-    # Extract text and save parsed file
     try:
         text = extract_text(str(file_path))
     except Exception as e:
@@ -50,19 +67,17 @@ def prepare_document_for_processing(
     dest_parsed = paths.parsed / parsed_name
     dest_parsed.write_text(text, encoding="utf-8")
 
-    # Write stub
     stub = {
-        "source_file": str(dest_raw),
-        "parsed_file": str(dest_parsed),
-        "source_ext": file_path.suffix.lower().lstrip("."),
+        "file_info": _build_file_info(
+            source_path=dest_raw, parsed_path=dest_parsed, text=text
+        ),
+        "chunk_map": None,
     }
 
     stub_file = paths.metadata / f"{parsed_name}.stub.json"
     stub_file.write_text(json.dumps(stub, indent=2), encoding="utf-8")
 
-    logger.info("Saved stub locally: %s", stub_file)
-    logger.info("Uploaded parsed version to: %s", dest_parsed)
-
+    logger.info("Prepared %s → %s", dest_raw.name, dest_parsed.name)
     return stub
 
 

--- a/src/core/workflows/main_commands.py
+++ b/src/core/workflows/main_commands.py
@@ -46,7 +46,7 @@ This module contains two core functions to classify documents. `classify()` supp
 
 import json
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from core.configuration.config_registry import get_path_config, get_remote_config
 from core.configuration.path_config import PathConfig
@@ -58,6 +58,184 @@ from core.parsing.topic_segmenter import segment_text
 from core.storage.upload_local import upload_file
 
 MAX_CHARS = 16000
+
+
+def _chunk_metadata_path(name: str, paths: PathConfig) -> Path:
+    return paths.metadata / f"{name}.chunks.json"
+
+
+def _load_stub(name: str, paths: PathConfig) -> tuple[Dict[str, Any], Path]:
+    stub_path = paths.metadata / f"{name}.stub.json"
+    if stub_path.exists():
+        try:
+            return json.loads(stub_path.read_text("utf-8")), stub_path
+        except json.JSONDecodeError:
+            return {}, stub_path
+    return {}, stub_path
+
+
+def _write_stub(path: Path, stub: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(stub, indent=2), encoding="utf-8")
+
+
+def _enforce_window(chunk: str) -> List[str]:
+    trimmed = chunk.strip()
+    if not trimmed:
+        return []
+    if len(trimmed) <= MAX_CHARS:
+        return [trimmed]
+    return chunk_text(trimmed, max_chars=MAX_CHARS)
+
+
+def _chunk_texts(
+    text: str, segmentation: Literal["semantic", "paragraph"], use_chunks: bool
+) -> List[str]:
+    if not use_chunks:
+        return [text.strip()]
+
+    if segmentation == "semantic":
+        raw_chunks = segment_text(text)
+        if not raw_chunks:
+            raw_chunks = chunk_text(text, max_chars=MAX_CHARS)
+    else:
+        raw_chunks = chunk_text(text, max_chars=MAX_CHARS)
+
+    normalized: List[str] = []
+    for chunk in raw_chunks:
+        normalized.extend(_enforce_window(chunk))
+    return [c for c in normalized if c.strip()]
+
+
+def _build_chunk_records(
+    name: str,
+    text: str,
+    segmentation: Literal["semantic", "paragraph"],
+    use_chunks: bool,
+) -> List[Dict[str, Any]]:
+    texts = _chunk_texts(text, segmentation, use_chunks)
+    if not texts:
+        texts = [text.strip()]
+
+    stem = Path(name).stem
+    records: List[Dict[str, Any]] = []
+    search_pos = 0
+    strategy = segmentation if use_chunks else "single"
+
+    for idx, chunk_text in enumerate(texts):
+        chunk_id = f"{stem}_chunk{idx:02d}"
+        start_idx = text.find(chunk_text, search_pos)
+        if start_idx == -1:
+            start_idx = search_pos
+        end_idx = start_idx + len(chunk_text)
+        search_pos = end_idx
+        records.append(
+            {
+                "id": chunk_id,
+                "order": idx,
+                "strategy": strategy,
+                "text": chunk_text,
+                "char_start": start_idx,
+                "char_end": end_idx,
+                "char_length": len(chunk_text),
+            }
+        )
+
+    return records
+
+
+def build_chunk_map(records: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {
+        "strategy": records[0]["strategy"] if records else "single",
+        "context_window": MAX_CHARS,
+        "count": len(records),
+        "chunks": [
+            {
+                "id": record["id"],
+                "order": record["order"],
+                "char_start": record.get("char_start", 0),
+                "char_end": record.get("char_end", 0),
+                "char_length": record.get("char_length", 0),
+            }
+            for record in records
+        ],
+    }
+
+
+def _write_chunk_metadata(
+    name: str, records: List[Dict[str, Any]], paths: PathConfig
+) -> None:
+    chunk_path = _chunk_metadata_path(name, paths)
+    payload = []
+    for record in records:
+        payload.append(
+            {
+                "id": record["id"],
+                "order": record["order"],
+                "strategy": record["strategy"],
+                "char_start": record.get("char_start", 0),
+                "char_end": record.get("char_end", 0),
+                "char_length": record.get("char_length", len(record.get("text", ""))),
+                "text": record.get("text", ""),
+            }
+        )
+
+    chunk_path.parent.mkdir(parents=True, exist_ok=True)
+    chunk_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def load_chunk_metadata(
+    name: str, paths: PathConfig | None = None
+) -> List[Dict[str, Any]]:
+    paths = paths or get_path_config()
+    chunk_path = _chunk_metadata_path(name, paths)
+    if not chunk_path.exists():
+        return []
+    try:
+        records = json.loads(chunk_path.read_text("utf-8"))
+    except json.JSONDecodeError:
+        return []
+
+    for record in records:
+        if "char_length" not in record:
+            record["char_length"] = len(record.get("text", ""))
+    return records
+
+
+def prepare_chunk_plan(
+    name: str,
+    *,
+    chunked: bool = False,
+    segmentation: Literal["semantic", "paragraph"] = "semantic",
+    paths: PathConfig | None = None,
+    text: str | None = None,
+) -> tuple[str, List[Dict[str, Any]]]:
+    paths = paths or get_path_config()
+    parsed_path = paths.parsed / name
+    text = text if text is not None else parsed_path.read_text(encoding="utf-8")
+
+    doc_type, use_chunks = detect(text, chunked)
+    expected_strategy = segmentation if use_chunks else "single"
+
+    existing_records = load_chunk_metadata(name, paths=paths)
+    if existing_records and all("text" in rec for rec in existing_records):
+        stored_strategy = existing_records[0].get("strategy", expected_strategy)
+        if stored_strategy == expected_strategy:
+            stub, stub_path = _load_stub(name, paths)
+            stub.setdefault("file_info", stub.get("file_info", {}))
+            stub["chunk_map"] = build_chunk_map(existing_records)
+            _write_stub(stub_path, stub)
+            return doc_type, existing_records
+
+    records = _build_chunk_records(name, text, segmentation, use_chunks)
+    _write_chunk_metadata(name, records, paths)
+
+    stub, stub_path = _load_stub(name, paths)
+    stub.setdefault("file_info", stub.get("file_info", {}))
+    stub["chunk_map"] = build_chunk_map(records)
+    _write_stub(stub_path, stub)
+
+    return doc_type, records
 
 
 def get_parsed_text(name: str) -> str:
@@ -87,33 +265,81 @@ def detect(text: str, force_chunked: bool) -> tuple[str, bool]:
 
 def segment(text: str, segmentation: Literal["semantic", "paragraph"]) -> list[str]:
     """Split text into chunks using the configured segmentation strategy."""
-    if segmentation == "semantic":
-        raw_chunks = segment_text(text)
-        if not raw_chunks:
-            raw_chunks = chunk_text(text)
-    else:
-        raw_chunks = chunk_text(text)
-    return raw_chunks
+    return _chunk_texts(text, segmentation, True)
 
 
-def summarize(chunks: list[str], doc_type: str) -> dict:
-    """Summarize provided chunks and merge results when necessary."""
-    if len(chunks) == 1:
-        return summarize_text(chunks[0], doc_type=doc_type)
+def summarize_records(
+    records: List[Dict[str, Any]], doc_type: str
+) -> tuple[dict, List[dict]]:
+    """Summarize provided chunk records and merge results when necessary."""
+    if not records:
+        raise ValueError("No chunk records supplied for summarization")
 
     block_results = [
-        summarize_text(chunk, doc_type=doc_type) for chunk in chunks if chunk.strip()
+        summarize_text(record["text"], doc_type=doc_type) for record in records
     ]
-    return merge_metadata_blocks(block_results)
+
+    if len(block_results) == 1:
+        return block_results[0], block_results
+
+    merged = merge_metadata_blocks(block_results)
+    return merged, block_results
 
 
 def merge_stubs(name: str, metadata: dict, paths: PathConfig) -> dict:
     """Overlay stub metadata onto generated metadata if present."""
     stub_path = paths.metadata / f"{name}.stub.json"
-    if stub_path.exists():
+    if not stub_path.exists():
+        return metadata
+
+    try:
         stub = json.loads(stub_path.read_text("utf-8"))
-        metadata.update(stub)
+    except json.JSONDecodeError:
+        return metadata
+
+    file_info = stub.get("file_info")
+    if isinstance(file_info, dict):
+        merged_info = {**file_info, **metadata.get("file_info", {})}
+        metadata["file_info"] = merged_info
+
+    if "chunk_map" in stub and "chunk_map" not in metadata:
+        metadata["chunk_map"] = stub["chunk_map"]
+
+    for key, value in stub.items():
+        if key in {"file_info", "chunk_map"}:
+            continue
+        metadata.setdefault(key, value)
+
     return metadata
+
+
+def _combine_chunk_results(
+    records: List[Dict[str, Any]], chunk_outputs: List[dict]
+) -> List[Dict[str, Any]]:
+    keys_to_copy = [
+        "summary",
+        "topics",
+        "tags",
+        "themes",
+        "priority",
+        "tone",
+        "stage",
+        "depth",
+        "category",
+    ]
+    combined: List[Dict[str, Any]] = []
+    for record, output in zip(records, chunk_outputs):
+        entry: Dict[str, Any] = {
+            "id": record["id"],
+            "order": record["order"],
+            "strategy": record["strategy"],
+            "char_length": record.get("char_length", len(record.get("text", ""))),
+        }
+        for key in keys_to_copy:
+            if key in output:
+                entry[key] = output[key]
+        combined.append(entry)
+    return combined
 
 
 def persist(name: str, metadata: dict, paths: PathConfig) -> dict:
@@ -129,6 +355,7 @@ def classify(
     chunked: bool = False,
     segmentation: Literal["semantic", "paragraph"] = "semantic",
     paths: PathConfig | None = None,
+    chunk_records: Optional[List[Dict[str, Any]]] = None,
 ) -> dict:
     """Summarize a parsed document into metadata."""
     paths = paths or get_path_config()
@@ -137,12 +364,35 @@ def classify(
 
     doc_type, use_chunks = detect(text, chunked)
 
-    if use_chunks:
-        chunks = segment(text, segmentation)
+    if not chunk_records:
+        doc_type, chunk_records = prepare_chunk_plan(
+            name,
+            chunked=chunked,
+            segmentation=segmentation,
+            paths=paths,
+            text=text,
+        )
     else:
-        chunks = [text]
+        if not all("text" in record for record in chunk_records):
+            doc_type, chunk_records = prepare_chunk_plan(
+                name,
+                chunked=chunked,
+                segmentation=segmentation,
+                paths=paths,
+                text=text,
+            )
+        else:
+            stub, stub_path = _load_stub(name, paths)
+            stub.setdefault("file_info", stub.get("file_info", {}))
+            stub["chunk_map"] = build_chunk_map(chunk_records)
+            _write_stub(stub_path, stub)
+            chunk_path = _chunk_metadata_path(name, paths)
+            if not chunk_path.exists():
+                _write_chunk_metadata(name, chunk_records, paths)
 
-    metadata = summarize(chunks, doc_type)
+    metadata, block_results = summarize_records(chunk_records, doc_type)
+    metadata["chunk_map"] = build_chunk_map(chunk_records)
+    metadata["chunks"] = _combine_chunk_results(chunk_records, block_results)
     metadata = merge_stubs(name, metadata, paths)
     return persist(name, metadata, paths)
 

--- a/src/scripts/pipeline.py
+++ b/src/scripts/pipeline.py
@@ -1,11 +1,20 @@
-# scripts/pipeline.py
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
 from pathlib import Path
+from typing import Dict, List
 
 from core.configuration.config_registry import get_path_config
 from core.configuration.path_config import PathConfig
 from core.logger import get_logger
+from core.metadata.schema import validate_metadata
 
 logger = get_logger(__name__)
+
+PIPELINE_STAGES = ("upload", "chunk", "classify", "embed", "cluster")
+_STAGE_INDEX = {name: idx for idx, name in enumerate(PIPELINE_STAGES)}
 
 
 def upload_and_prepare(*args, **kwargs):
@@ -20,51 +29,271 @@ def classify(*args, **kwargs):
     return _classify(*args, **kwargs)
 
 
+def prepare_chunk_plan(*args, **kwargs):
+    from core.workflows.main_commands import prepare_chunk_plan as _prepare
+
+    return _prepare(*args, **kwargs)
+
+
+def load_chunk_metadata(*args, **kwargs):
+    from core.workflows.main_commands import load_chunk_metadata as _load
+
+    return _load(*args, **kwargs)
+
+
 def generate_embeddings(*args, **kwargs):
     from core.embeddings.embedder import generate_embeddings as _generate
 
     return _generate(*args, **kwargs)
 
 
-def upload_file(file: Path, paths: PathConfig) -> None:
-    """Upload and prepare a single file for downstream processing."""
-    try:
-        upload_and_prepare(file, paths=paths)
-    except Exception as exc:  # pragma: no cover - defensive logging
-        logger.error("Upload failed: %s — %s", file.name, exc)
+def _setup_pipeline_logger(paths: PathConfig) -> tuple[logging.Handler, Path]:
+    log_dir = paths.root / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"pipeline-{datetime.utcnow().strftime('%Y%m%d-%H%M%S')}.log"
+
+    handler = logging.FileHandler(log_path, encoding="utf-8")
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    )
+    logger.addHandler(handler)
+    logger.info("Detailed pipeline log: %s", log_path)
+    return handler, log_path
 
 
-def classify_document(
-    file: Path,
+def _teardown_pipeline_logger(handler: logging.Handler) -> None:
+    logger.removeHandler(handler)
+    handler.close()
+
+
+def _stage_enabled(start_from: str, stage: str) -> bool:
+    return _STAGE_INDEX[start_from] <= _STAGE_INDEX[stage]
+
+
+def _resolve_input_files(input_dir: Path) -> List[Path]:
+    return sorted(path for path in input_dir.rglob("*") if path.is_file())
+
+
+def _run_upload_stage(paths: PathConfig, input_dir: Path) -> None:
+    files_to_upload = _resolve_input_files(input_dir)
+    if not files_to_upload:
+        logger.info("No new files discovered under %s", input_dir)
+        return
+
+    logger.info("Uploading %d document(s) from %s", len(files_to_upload), input_dir)
+    for file in files_to_upload:
+        try:
+            upload_and_prepare(file, paths=paths)
+            logger.info("Prepared %s", file.name)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to prepare %s: %s", file, exc, exc_info=True)
+
+
+def _run_chunk_stage(
+    paths: PathConfig,
     *,
     chunked: bool,
     segmentation: str,
-    overwrite: bool,
+) -> Dict[str, List[Dict[str, object]]]:
+    chunk_cache: Dict[str, List[Dict[str, object]]] = {}
+    parsed_files = sorted(paths.parsed.glob("*.txt"))
+    if not parsed_files:
+        logger.info("No parsed documents available for chunking")
+        return chunk_cache
+
+    segmentation_mode = segmentation.lower()
+    for parsed_file in parsed_files:
+        name = parsed_file.name
+        try:
+            doc_type, records = prepare_chunk_plan(
+                name,
+                chunked=chunked,
+                segmentation="semantic"
+                if segmentation_mode == "semantic"
+                else "paragraph",
+                paths=paths,
+            )
+            chunk_cache[name] = records
+            strategy = records[0]["strategy"] if records else "single"
+            logger.info(
+                "Chunked %s (%s) into %d %s segment(s)",
+                name,
+                doc_type,
+                len(records),
+                strategy,
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Chunking failed for %s: %s", name, exc, exc_info=True)
+    return chunk_cache
+
+
+def _load_chunk_cache(paths: PathConfig) -> Dict[str, List[Dict[str, object]]]:
+    cache: Dict[str, List[Dict[str, object]]] = {}
+    for parsed_file in sorted(paths.parsed.glob("*.txt")):
+        name = parsed_file.name
+        records = load_chunk_metadata(name, paths=paths)
+        if records:
+            cache[name] = records
+        else:
+            logger.warning("Chunk metadata missing for %s; will regenerate on demand", name)
+    return cache
+
+
+def _run_classification_stage(
     paths: PathConfig,
+    *,
+    overwrite: bool,
+    chunked: bool,
+    segmentation: str,
+    chunk_cache: Dict[str, List[Dict[str, object]]],
 ) -> None:
-    """Classify a parsed document if classification is required."""
-    name = file.name
-    meta_path = paths.metadata / f"{name}.meta.json"
-    if meta_path.exists() and not overwrite:
-        logger.info("Skipping %s (already classified)", name)
+    parsed_files = sorted(paths.parsed.glob("*.txt"))
+    if not parsed_files:
+        logger.info("No parsed documents available for classification")
+        return
+
+    segmentation_mode = segmentation.lower()
+    for parsed_file in parsed_files:
+        name = parsed_file.name
+        meta_path = paths.metadata / f"{name}.meta.json"
+        if meta_path.exists() and not overwrite:
+            logger.info("Skipping classification for %s (metadata exists)", name)
+            continue
+
+        try:
+            records = chunk_cache.get(name)
+            classify(
+                name,
+                chunked=chunked,
+                segmentation="semantic"
+                if segmentation_mode == "semantic"
+                else "paragraph",
+                paths=paths,
+                chunk_records=records,
+            )
+            logger.info(
+                "Classified %s using %d chunk(s)",
+                name,
+                len(records) if records else 1,
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Classification failed for %s: %s", name, exc, exc_info=True)
+
+
+def _run_embedding_stage(paths: PathConfig, method: str) -> None:
+    logger.info("Generating embeddings using %s content", method)
+    try:
+        generate_embeddings(
+            source_dir=paths.parsed if method != "raw" else paths.raw,
+            method=method,
+            out_path=paths.root / "rich_doc_embeddings.json",
+            segment_mode=paths.semantic_chunking,
+        )
+        logger.info("Embeddings stored at %s", paths.root / "rich_doc_embeddings.json")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Embedding generation failed: %s", exc, exc_info=True)
+        raise
+
+
+def _run_cluster_stage(
+    paths: PathConfig,
+    *,
+    cluster_method: str,
+    label_model: str,
+) -> None:
+    embedding_path = paths.root / "rich_doc_embeddings.json"
+    if not embedding_path.exists():
+        logger.warning(
+            "Embedding file %s is missing; skipping clustering stage", embedding_path
+        )
         return
 
     try:
-        classify(name, chunked=chunked, segmentation=segmentation, paths=paths)
-        logger.info("%s classified", name)
+        from core.embeddings.loader import load_embeddings
+        from core.clustering.algorithms import cluster_embeddings, reduce_dimensions
+        from core.clustering.labeling import label_clusters
+        from core.clustering.export import export_cluster_data
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional deps
+        logger.warning("Clustering dependencies unavailable: %s", exc)
+        return
+
+    try:
+        doc_ids, matrix = load_embeddings(embedding_path)
     except Exception as exc:  # pragma: no cover - defensive logging
-        logger.error("Classification failed: %s — %s", name, exc)
+        logger.error("Failed to load embeddings: %s", exc, exc_info=True)
+        return
+
+    if not doc_ids:
+        logger.info("Embedding store is empty; skipping clustering stage")
+        return
+
+    try:
+        coords = reduce_dimensions(matrix)
+        labels = cluster_embeddings(matrix, method=cluster_method)
+        label_list = [int(label) for label in labels.tolist()]
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional deps
+        logger.warning("Clustering dependency missing: %s", exc)
+        return
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Clustering computation failed: %s", exc, exc_info=True)
+        return
+
+    try:
+        label_map = label_clusters(doc_ids, label_list, paths.metadata, model=label_model, preview=False)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Cluster labeling failed: %s", exc, exc_info=True)
+        label_map = {f"cluster_{label}": f"cluster_{label}" for label in set(label_list) if label != -1}
+
+    try:
+        export_cluster_data(
+            doc_ids,
+            coords.tolist(),
+            label_list,
+            label_map,
+            paths.output / "cluster_output",
+            paths.metadata,
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Failed to export clustering artefacts: %s", exc, exc_info=True)
+
+    _update_metadata_with_clusters(doc_ids, label_list, label_map, paths, cluster_method)
+    logger.info("Clustering stage complete (%d document(s))", len(doc_ids))
 
 
-def embed_document(*, method: str, paths: PathConfig) -> None:
-    """Generate embeddings for the processed corpus."""
-    logger.info("Generating embeddings and updating vector index...")
-    generate_embeddings(
-        source_dir=paths.parsed if method != "raw" else paths.raw,
-        method=method,
-        out_path=paths.root / "rich_doc_embeddings.json",
-        segment_mode=paths.semantic_chunking,
-    )
+def _update_metadata_with_clusters(
+    doc_ids: List[str],
+    labels: List[int],
+    label_map: Dict[str, str],
+    paths: PathConfig,
+    method: str,
+) -> None:
+    for doc_id, label in zip(doc_ids, labels):
+        meta_path = paths.metadata / f"{doc_id}.meta.json"
+        if not meta_path.exists():
+            continue
+
+        try:
+            metadata = json.loads(meta_path.read_text("utf-8"))
+        except Exception:  # pragma: no cover - defensive logging
+            logger.warning("Unable to load metadata for %s to attach cluster info", doc_id)
+            continue
+
+        if label == -1:
+            cluster_info = {"id": "noise", "label": "Noise", "method": method}
+        else:
+            cluster_id = f"cluster_{label}"
+            cluster_info = {
+                "id": cluster_id,
+                "label": label_map.get(cluster_id, cluster_id),
+                "method": method,
+            }
+
+        metadata["cluster"] = cluster_info
+        try:
+            validate_metadata(metadata)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("Cluster update for %s failed schema validation: %s", doc_id, exc)
+        meta_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
 
 
 def run_pipeline(
@@ -74,38 +303,73 @@ def run_pipeline(
     method: str = "summary",
     segmentation: str = "semantic",
     paths: PathConfig | None = None,
-):
-    """
-    Full ingestion pipeline:
-    1. Upload + parse
-    2. Classify
-    3. Generate embeddings
+    start_from: str = "upload",
+    cluster_method: str = "hdbscan",
+    label_model: str = "gpt-4",
+) -> None:
+    """Run the full document processing pipeline.
 
     Args:
-        input_dir (Path): Folder containing source documents
-        chunked (bool): Use chunking for classification
-        overwrite (bool): Reclassify even if .meta.json exists
-        method (str): Text source for embeddings: parsed, summary, raw, meta
+        input_dir: Folder containing source documents.
+        chunked: Force chunking even if under context window.
+        overwrite: Reclassify documents that already have metadata.
+        method: Embedding source text (parsed, summary, raw, meta).
+        segmentation: Chunking strategy (semantic or paragraph).
+        start_from: Pipeline stage to start at when resuming work.
+        cluster_method: Clustering algorithm (hdbscan or spectral).
+        label_model: OpenAI model used for cluster labeling.
     """
+
     paths = paths or get_path_config()
-
-    logger.info("Uploading and parsing raw files...")
-    files_to_upload = sorted(
-        (path for path in input_dir.rglob("*") if path.is_file()),
-        key=lambda path: str(path),
-    )
-    for file in files_to_upload:
-        upload_file(file, paths=paths)
-
-    logger.info("Classifying parsed documents...")
-    for file in sorted(paths.parsed.glob("*.txt")):
-        classify_document(
-            file,
-            chunked=chunked,
-            segmentation=segmentation,
-            overwrite=overwrite,
-            paths=paths,
+    start_key = start_from.lower()
+    if start_key not in _STAGE_INDEX:
+        raise ValueError(
+            f"Unknown pipeline stage '{start_from}'. Valid stages: {', '.join(PIPELINE_STAGES)}"
         )
 
-    embed_document(method=method, paths=paths)
+    handler, _ = _setup_pipeline_logger(paths)
+    chunk_cache: Dict[str, List[Dict[str, object]]] = {}
+    try:
+        if _stage_enabled(start_key, "upload"):
+            _run_upload_stage(paths, input_dir)
+        else:
+            logger.info("Skipping upload stage (start_from=%s)", start_from)
+
+        if _stage_enabled(start_key, "chunk"):
+            chunk_cache = _run_chunk_stage(
+                paths,
+                chunked=chunked,
+                segmentation=segmentation,
+            )
+        else:
+            logger.info("Skipping chunk stage (start_from=%s)", start_from)
+            chunk_cache = _load_chunk_cache(paths)
+
+        if _stage_enabled(start_key, "classify"):
+            _run_classification_stage(
+                paths,
+                overwrite=overwrite,
+                chunked=chunked,
+                segmentation=segmentation,
+                chunk_cache=chunk_cache,
+            )
+        else:
+            logger.info("Skipping classification stage (start_from=%s)", start_from)
+
+        if _stage_enabled(start_key, "embed"):
+            _run_embedding_stage(paths, method)
+        else:
+            logger.info("Skipping embedding stage (start_from=%s)", start_from)
+
+        if _stage_enabled(start_key, "cluster"):
+            _run_cluster_stage(
+                paths,
+                cluster_method=cluster_method,
+                label_model=label_model,
+            )
+        else:
+            logger.info("Skipping clustering stage (start_from=%s)", start_from)
+    finally:
+        _teardown_pipeline_logger(handler)
+
     logger.info("Pipeline complete.")

--- a/tests/test_config_registry_schema_override.py
+++ b/tests/test_config_registry_schema_override.py
@@ -88,19 +88,14 @@ def test_cli_pipeline_uses_cached_schema(
         captured["schema"] = paths.schema
         return None
 
-    def fake_run_all_steps(**kwargs):
-        return None
-
     registry = importlib.import_module("core.configuration.config_registry")
     registry.configure(path_config_path=None)
 
     original_get = pipeline_cli.get_path_config
     original_run_pipeline = pipeline_cli.run_pipeline
-    original_run_all_steps = pipeline_cli.run_all_steps
     try:
         pipeline_cli.get_path_config = lambda: base  # type: ignore[assignment]
         pipeline_cli.run_pipeline = fake_run_pipeline  # type: ignore[assignment]
-        pipeline_cli.run_all_steps = fake_run_all_steps  # type: ignore[assignment]
 
         result = runner.invoke(
             pipeline_cli.app,
@@ -112,7 +107,6 @@ def test_cli_pipeline_uses_cached_schema(
     finally:
         pipeline_cli.get_path_config = original_get  # type: ignore[assignment]
         pipeline_cli.run_pipeline = original_run_pipeline  # type: ignore[assignment]
-        pipeline_cli.run_all_steps = original_run_all_steps  # type: ignore[assignment]
 
     assert result.exit_code == 0
     assert captured["schema"] == base.schema

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,7 +4,7 @@ import sys
 import tempfile
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -137,9 +137,20 @@ def test_run_pipeline_happy_path(sample_paths: PathConfig) -> None:
     """The pipeline should upload, classify, and embed documents in order."""
     with (
         patch.object(pipeline, "upload_and_prepare") as upload_mock,
+        patch.object(pipeline, "prepare_chunk_plan") as chunk_mock,
         patch.object(pipeline, "classify") as classify_mock,
         patch.object(pipeline, "generate_embeddings") as embed_mock,
     ):
+        chunk_record = {
+            "id": "example_chunk00",
+            "order": 0,
+            "strategy": "single",
+            "text": "parsed content",
+            "char_start": 0,
+            "char_end": 13,
+            "char_length": 13,
+        }
+        chunk_mock.return_value = ("standard", [chunk_record])
         pipeline.run_pipeline(
             input_dir=sample_paths.raw,
             chunked=False,
@@ -154,11 +165,19 @@ def test_run_pipeline_happy_path(sample_paths: PathConfig) -> None:
     assert uploaded_path == sample_paths.raw / "example.md"
     assert upload_mock.call_args.kwargs == {"paths": sample_paths}
 
+    chunk_mock.assert_called_once_with(
+        "example.txt",
+        chunked=False,
+        segmentation="semantic",
+        paths=sample_paths,
+    )
+
     classify_mock.assert_called_once_with(
         "example.txt",
         chunked=False,
         segmentation="semantic",
         paths=sample_paths,
+        chunk_records=[chunk_record],
     )
 
     embed_mock.assert_called_once_with(
@@ -178,9 +197,24 @@ def test_run_pipeline_processes_nested_directories(sample_paths: PathConfig) -> 
 
     with (
         patch.object(pipeline, "upload_and_prepare") as upload_mock,
+        patch.object(pipeline, "prepare_chunk_plan") as chunk_mock,
         patch.object(pipeline, "classify") as classify_mock,
         patch.object(pipeline, "generate_embeddings") as embed_mock,
     ):
+        chunk_mock.return_value = (
+            "standard",
+            [
+                {
+                    "id": "example_chunk00",
+                    "order": 0,
+                    "strategy": "single",
+                    "text": "parsed content",
+                    "char_start": 0,
+                    "char_end": 13,
+                    "char_length": 13,
+                }
+            ],
+        )
         pipeline.run_pipeline(
             input_dir=sample_paths.raw,
             chunked=False,
@@ -196,5 +230,51 @@ def test_run_pipeline_processes_nested_directories(sample_paths: PathConfig) -> 
         nested_file,
     ]
 
+    chunk_mock.assert_called_once()
     classify_mock.assert_called_once()
+    embed_mock.assert_called_once()
+
+
+def test_run_pipeline_start_from_classify(sample_paths: PathConfig) -> None:
+    """Resuming from classification should skip upload and chunk stages."""
+    chunk_records = [
+        {
+            "id": "example_chunk00",
+            "order": 0,
+            "strategy": "single",
+            "text": "parsed content",
+            "char_start": 0,
+            "char_end": 13,
+            "char_length": 13,
+        }
+    ]
+
+    with (
+        patch.object(pipeline, "upload_and_prepare") as upload_mock,
+        patch.object(pipeline, "prepare_chunk_plan") as chunk_mock,
+        patch.object(pipeline, "load_chunk_metadata") as load_chunk_mock,
+        patch.object(pipeline, "classify") as classify_mock,
+        patch.object(pipeline, "generate_embeddings") as embed_mock,
+    ):
+        load_chunk_mock.return_value = chunk_records
+        pipeline.run_pipeline(
+            input_dir=sample_paths.raw,
+            chunked=False,
+            overwrite=True,
+            method="summary",
+            segmentation="semantic",
+            paths=sample_paths,
+            start_from="classify",
+        )
+
+    upload_mock.assert_not_called()
+    chunk_mock.assert_not_called()
+    load_chunk_mock.assert_called()
+    classify_mock.assert_called_once_with(
+        "example.txt",
+        chunked=False,
+        segmentation="semantic",
+        paths=sample_paths,
+        chunk_records=chunk_records,
+    )
     embed_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- restructure the ingestion pipeline to run upload, chunk planning, classification, embedding, and clustering in order with resumable stages and file-based logging
- enhance classification and stubs to persist chunk metadata, attach per-chunk results, and extend the metadata schema to cover chunk and cluster information
- expose the new controls through the CLI, refresh purpose docs, and update tests for the new workflow

## Testing
- pytest tests/test_pipeline.py tests/test_config_registry_schema_override.py

------
https://chatgpt.com/codex/tasks/task_e_68f6e8b8e45483238e6d75bd65d2d7fe