### PR TITLE
Add exponential backoff retries for OpenAI calls

### DIFF
--- a/Codex_++/purpose_files/core.embeddings.embedder.purpose.md
+++ b/Codex_++/purpose_files/core.embeddings.embedder.purpose.md
@@ -15,7 +15,7 @@
 - @schema-version: 0.3
 - @ai-risk-pii: medium
 - @ai-risk-performance: "OpenAI batching mitigates API round-trips but remains network bound."
-- @ai-dependencies: core.configuration.config_registry, core.parsing.chunk_text, core.parsing.semantic_chunk, core.utils.budget_tracker, core.vectorstore.faiss_store, hashlib, json, numpy, openai, pathlib, tiktoken
+- @ai-dependencies: core.configuration.config_registry, core.parsing.chunk_text, core.parsing.semantic_chunk, core.utils.budget_tracker, core.utils.openai_retry, core.vectorstore.faiss_store, hashlib, json, numpy, openai, pathlib, tiktoken
 - @ai-used-by: scripts.pipeline, cli.embed, core.retrieval.retriever
 - @ai-downstream: core.vectorstore.faiss_store, core.retrieval.retriever, cli.pipeline
 
@@ -52,6 +52,6 @@ The embedder module encapsulates all embedding generation paths. It caches the O
 - Shares Trace A configuration contract with CLI + workflow modules—no inline schema literals remain after consolidation.
 
 ### Risks & Mitigations
-- **Rate limits / cost spikes:** budget tracker halts requests before spend overrun; chunk batching reduces API calls.
+- **Rate limits / cost spikes:** budget tracker halts requests before spend overrun, and OpenAI calls are wrapped in exponential backoff so batches pause instead of failing when 429s occur.
 - **Schema drift:** reliance on `PathConfig` ensures metadata directories align with validated schema path.
 - **Large documents:** long inputs automatically chunked and averaged to avoid OpenAI token limits.

--- a/Codex_++/purpose_files/core.llm.invoke.purpose.md
+++ b/Codex_++/purpose_files/core.llm.invoke.purpose.md
@@ -39,9 +39,10 @@
 
 ### 🔗 Dependencies
 - `tiktoken` for token estimation to feed `BudgetTracker`.
-- `openai.OpenAI` chat completions client.
+- `openai.OpenAI` chat completions client wrapped with retry backoff.
 - `core.configuration.remote_config.RemoteConfig` for credentials.
 - `core.utils.budget_tracker.get_budget_tracker` for spend enforcement.
+- `core.utils.openai_retry.retry_with_exponential_backoff` for resilient API usage.
 - Prompt templates stored under `core/llm/prompts`.
 
 ### 🤝 Integration Points
@@ -53,4 +54,5 @@
 - @ai-role: executor
 - @ai-used-by: core.synthesis.summarizer
 - @ai-downstream: core.workflows.insurance_verification, cli.pipeline
+- Built-in exponential backoff pauses on OpenAI rate limits to avoid skipping source documents.
 - Coordination: participates in agent loops where retriever output feeds summarizer before response synthesis; `summarize_text` must emit JSON conforming to downstream schema expectations for section/topic summaries.

--- a/Codex_++/purpose_files/core.utils.openai_retry.purpose.md
+++ b/Codex_++/purpose_files/core.utils.openai_retry.purpose.md
@@ -1,0 +1,52 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+
+- @ai-path: core.utils.openai_retry
+- @ai-source-file: core/utils/openai_retry.py
+- @ai-role: resilience
+- @ai-intent: "Provide shared exponential backoff logic for OpenAI requests across the stack."
+- @schema-version: 0.2
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @human-reviewed: false
+- @ai-risk-performance: low
+- @ai-risk-operations: "Centralized retry policy ensures consistent handling of rate limits."
+
+# Module: core.utils.openai_retry
+> Consolidated retry helper that pauses and retries OpenAI calls when rate limits or temporary 429 errors occur.
+
+### 🎯 Intent & Responsibility
+- Offer `retry_with_exponential_backoff` that wraps any callable interacting with OpenAI.
+- Normalize logging of rate-limit errors so operators see pause durations and attempt counts.
+- Provide configurable retry/backoff parameters while defaulting to conservative pauses.
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Brief Description |
+|-----------|------|------|-------------------|
+| 📥 In | operation | Callable[[], T] | Zero-argument callable invoking an OpenAI API request. |
+| 📥 In | retries | int | Maximum number of attempts before surfacing the exception (default 5). |
+| 📥 In | base_delay | float | Initial delay before the first retry in seconds (default 2.0). |
+| 📥 In | backoff_factor | float | Multiplier applied to the delay after each retry (default 2.0). |
+| 📥 In | retriable_status_codes | Iterable[int] | HTTP status codes treated as retryable beyond `RateLimitError` (default `(429,)`). |
+| 📥 In | logger | logging.Logger \| None | Optional logger used for resilience telemetry. |
+| 📤 Out | result | T | The successful return value from ``operation``. Raises the last exception if retries exhausted. |
+
+### 🔗 Dependencies
+- `openai.RateLimitError`, `openai.APIStatusError` to detect throttling and HTTP 429 responses.
+- `core.logger.get_logger` for structured logs when caller omits a logger.
+- Standard library `time.sleep` for pause management.
+
+### 🤝 Integration Points
+- Invoked by `core.llm.invoke`, `core.embeddings.embedder`, GUI chat, and clustering labelers to guard OpenAI calls.
+- Downstream agents (retriever, summarizer, chat UI) receive consistent retry semantics via this helper.
+- Coordinates with `BudgetTracker` indirectly by allowing cost checks to pass once before shared retries occur.
+
+### 🗣 Dialogic Notes
+- @ai-used-by: core.llm.invoke, core.embeddings.embedder, gui.chat_gui, core.clustering.labeling, core.clustering.cluster_helpers
+- @ai-coordination: Sits inside LLM/embedding call loops; respects Run cadence by pausing instead of skipping items when throttled.
+- @ai-risks: Excessive retries on permanent failures are avoided by surfacing the last error after bounded attempts.

--- a/Codex_++/purpose_files/core_clustering_combined.purpose.md
+++ b/Codex_++/purpose_files/core_clustering_combined.purpose.md
@@ -24,7 +24,7 @@
 
 ### 🔗 Dependencies
 - `umap-learn`, `hdbscan`, `sklearn.cluster` – Clustering and dimensionality reduction
-- `openai` – GPT-based cluster labeling
+- `openai` – GPT-based cluster labeling wrapped with retry backoff utilities
 - `pandas`, `matplotlib`, `json`, `pathlib` – Plotting, I/O, and tabular output
 - `core.embeddings.loader`, `core.config.config_registry`, `core.clustering.labeling`, `core.clustering.export`, `core.clustering.cluster_utils`
 

--- a/Codex_++/purpose_files/gui.chat_gui.purpose.md
+++ b/Codex_++/purpose_files/gui.chat_gui.purpose.md
@@ -34,7 +34,7 @@
 
 ### 🔗 Dependencies
 - `streamlit`
-- `openai`, `tiktoken`
+- `openai`, `tiktoken`, `core.utils.openai_retry`
 - `core.config.config_registry.get_remote_config`
 - `core.utils.budget_tracker.get_budget_tracker`
 
@@ -46,4 +46,4 @@
 ### 9 Pipeline Integration
 - **Coordination Mechanics:** Standalone interface; loops via Streamlit callbacks.
 - **Integration Points:** Could later integrate with `Retriever` or `FrameStore` for RAG workflows.
-- **Risks:** Missing config or network failures will raise runtime errors; no retry logic implemented.
+- **Risks:** Missing config still raises runtime errors; rate limits trigger exponential backoff instead of skipping chats.

--- a/src/core/clustering/cluster_helpers.py
+++ b/src/core/clustering/cluster_helpers.py
@@ -10,6 +10,7 @@ import umap
 from sklearn.cluster import SpectralClustering
 
 from core.logger import get_logger
+from core.utils.openai_retry import retry_with_exponential_backoff
 
 logger = get_logger(__name__)
 
@@ -123,8 +124,13 @@ These are document topics:
 
 Provide a short (2–6 words) high-level label for this cluster:"""
 
-        response = openai.chat.completions.create(
-            model=model, messages=[{"role": "user", "content": prompt}], temperature=0.4
+        response = retry_with_exponential_backoff(
+            lambda: openai.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.4,
+            ),
+            logger=logger,
         )
 
         label = response.choices[0].message.content.strip()

--- a/src/core/clustering/labeling.py
+++ b/src/core/clustering/labeling.py
@@ -54,6 +54,7 @@ from openai import OpenAI
 
 from core.configuration.config_registry import get_remote_config
 from core.logger import get_logger
+from core.utils.openai_retry import retry_with_exponential_backoff
 
 logger = get_logger(__name__)
 
@@ -105,10 +106,13 @@ def label_clusters(
     Give a short 2–6 word descriptive label for this cluster:
     """
         try:
-            response = client.chat.completions.create(
-                model=model,
-                messages=[{"role": "user", "content": prompt}],
-                temperature=0.4,
+            response = retry_with_exponential_backoff(
+                lambda: client.chat.completions.create(
+                    model=model,
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=0.4,
+                ),
+                logger=logger,
             )
             label = response.choices[0].message.content.strip()
         except Exception as e:

--- a/src/core/embeddings/embedder.py
+++ b/src/core/embeddings/embedder.py
@@ -14,6 +14,7 @@ from core.configuration.config_registry import get_path_config, get_remote_confi
 from core.logger import get_logger
 from core.utils.budget_tracker import get_budget_tracker
 from core.vectorstore.faiss_store import FaissStore
+from core.utils.openai_retry import retry_with_exponential_backoff
 
 MAX_EMBED_TOKENS = 8191
 MODEL_DIMS = {
@@ -71,7 +72,10 @@ def embed_text(text: str, model: str = "text-embedding-3-small") -> List[float]:
 
     if len(tokens) <= MAX_EMBED_TOKENS:
         _charge_budget(len(tokens), model, tracker)
-        response = client.embeddings.create(input=[text], model=model)
+        response = retry_with_exponential_backoff(
+            lambda: client.embeddings.create(input=[text], model=model),
+            logger=logger,
+        )
         return response.data[0].embedding
 
     # chunk into MAX_EMBED_TOKENS slices and average embeddings
@@ -80,7 +84,10 @@ def embed_text(text: str, model: str = "text-embedding-3-small") -> List[float]:
         chunk_tokens = tokens[i : i + MAX_EMBED_TOKENS]
         _charge_budget(len(chunk_tokens), model, tracker)
         chunk_text = enc.decode(chunk_tokens)
-        resp = client.embeddings.create(input=[chunk_text], model=model)
+        resp = retry_with_exponential_backoff(
+            lambda: client.embeddings.create(input=[chunk_text], model=model),
+            logger=logger,
+        )
         vectors.append(np.asarray(resp.data[0].embedding, dtype="float32"))
 
     return np.mean(vectors, axis=0).tolist()
@@ -124,7 +131,10 @@ def embed_text_batch(
         else:
             total_tokens = sum(short_tokens)
             _charge_budget(total_tokens, model, tracker)
-            response = embeddings_api(input=short_payload, model=model)
+            response = retry_with_exponential_backoff(
+                lambda: embeddings_api(input=short_payload, model=model),
+                logger=logger,
+            )
             for idx, data in zip(short_indices, response.data):
                 results[idx] = data.embedding
 

--- a/src/core/llm/invoke.py
+++ b/src/core/llm/invoke.py
@@ -62,7 +62,9 @@ from core.constants import (
     ERROR_OPENAI_RESPONSE_NOT_JSON,
     ERROR_PROMPT_FILE_NOT_FOUND,
 )
+from core.logger import get_logger
 from core.utils.budget_tracker import get_budget_tracker
+from core.utils.openai_retry import retry_with_exponential_backoff
 
 PROMPT_DIR = Path(__file__).parent / "prompts"
 
@@ -74,6 +76,9 @@ LLM_COMPLETION_COST_PER_1K = {
     "gpt-4": 0.06,
     "gpt-4o": 0.015,
 }
+
+
+logger = get_logger(__name__)
 
 
 def load_prompt(prompt_name: str) -> str:
@@ -102,11 +107,14 @@ def run_openai_completion(
         if not tracker.check(est_cost):
             raise RuntimeError(ERROR_BUDGET_EXCEEDED)
 
-    response = client.chat.completions.create(
-        model=model,
-        messages=[{"role": "user", "content": prompt}],
-        temperature=temperature,
-        max_tokens=max_tokens,
+    response = retry_with_exponential_backoff(
+        lambda: client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=temperature,
+            max_tokens=max_tokens,
+        ),
+        logger=logger,
     )
     return response.choices[0].message.content.strip()
 

--- a/src/core/utils/openai_retry.py
+++ b/src/core/utils/openai_retry.py
@@ -1,0 +1,78 @@
+"""Shared retry helpers for OpenAI API calls."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Iterable, TypeVar
+
+try:  # pragma: no cover - import depends on optional openai install
+    from openai import APIStatusError, RateLimitError
+except ImportError:  # pragma: no cover - fallback for test environments
+    class RateLimitError(Exception):
+        """Fallback RateLimitError when OpenAI SDK is unavailable."""
+
+    class APIStatusError(Exception):
+        """Fallback APIStatusError with an optional status_code attribute."""
+
+        def __init__(self, *args, status_code: int | None = None, **kwargs):
+            super().__init__(*args)
+            self.status_code = status_code
+
+from core.logger import get_logger
+
+T = TypeVar("T")
+
+_DEFAULT_STATUS_CODES = (429,)
+
+
+def retry_with_exponential_backoff(
+    operation: Callable[[], T],
+    *,
+    retries: int = 5,
+    base_delay: float = 2.0,
+    backoff_factor: float = 2.0,
+    retriable_status_codes: Iterable[int] = _DEFAULT_STATUS_CODES,
+    logger=None,
+) -> T:
+    """Execute ``operation`` with exponential backoff on rate-limit style failures."""
+
+    log = logger or get_logger(__name__)
+    delay = base_delay
+    last_error: Exception | None = None
+    status_codes = tuple(retriable_status_codes)
+
+    for attempt in range(1, retries + 1):
+        try:
+            return operation()
+        except RateLimitError as exc:  # pragma: no cover - network dependent
+            last_error = exc
+            log.warning(
+                "OpenAI rate limit encountered (attempt %s/%s): %s; sleeping for %.1f seconds",
+                attempt,
+                retries,
+                exc,
+                delay,
+            )
+        except APIStatusError as exc:  # pragma: no cover - network dependent
+            if exc.status_code in status_codes:
+                last_error = exc
+                log.warning(
+                    "OpenAI API status %s on attempt %s/%s: %s; sleeping for %.1f seconds",
+                    exc.status_code,
+                    attempt,
+                    retries,
+                    exc,
+                    delay,
+                )
+            else:
+                raise
+
+        time.sleep(delay)
+        delay *= backoff_factor
+
+    assert last_error is not None  # for type checkers
+    log.error("Exhausted OpenAI retries after %s attempts", retries)
+    raise last_error
+
+
+__all__ = ["retry_with_exponential_backoff"]

--- a/src/gui/chat_gui.py
+++ b/src/gui/chat_gui.py
@@ -10,7 +10,12 @@ from openai import OpenAI
 
 from core.configuration.config_registry import get_remote_config
 from core.llm.invoke import LLM_COMPLETION_COST_PER_1K, LLM_PROMPT_COST_PER_1K
+from core.logger import get_logger
 from core.utils.budget_tracker import get_budget_tracker  # type: ignore
+from core.utils.openai_retry import retry_with_exponential_backoff
+
+
+logger = get_logger(__name__)
 
 
 def run_openai_chat(
@@ -34,11 +39,14 @@ def run_openai_chat(
         if not tracker.check(est_cost):
             raise RuntimeError("Budget exceeded for chat request")
 
-    response = client.chat.completions.create(
-        model=model,
-        messages=messages,  # type: ignore[arg-type]
-        temperature=temperature,
-        max_tokens=max_tokens,
+    response = retry_with_exponential_backoff(
+        lambda: client.chat.completions.create(
+            model=model,
+            messages=messages,  # type: ignore[arg-type]
+            temperature=temperature,
+            max_tokens=max_tokens,
+        ),
+        logger=logger,
     )
     content = response.choices[0].message.content or ""
     return content.strip()


### PR DESCRIPTION
## Summary
- add a shared OpenAI retry helper that performs exponential backoff on rate-limit style failures
- wrap chat completions and embedding calls in the GUI, LLM invoke path, clustering utilities, and embedder with the new helper
- update module purpose files to document the shared resilience utility and new retry behaviour

## Testing
- pytest *(fails: jsonschema.exceptions.ValidationError: 'source_file' is a required property)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691269ee623883239c4664fe87bcc4c3)